### PR TITLE
OY-280 Upgrade RxJava major version, and kludge around random test failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <auditlog.api.version>8.3.0-SNAPSHOT</auditlog.api.version>
         <camel.version>2.12.1</camel.version>
         <cxf.version>3.2.4</cxf.version>
+        <fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
         <httpcomponents.version>4.5.2</httpcomponents.version>
         <jetty.version>9.2.11.v20150529</jetty.version>
         <jetty.webApp>../valintalaskentakoostepalvelu/target/valintalaskentakoostepalvelu.war</jetty.webApp>
@@ -22,6 +23,8 @@
         <slf4j.version>1.7.5</slf4j.version>
         <spring.security.version>4.1.2.RELEASE</spring.security.version>
         <spring.version>4.3.2.RELEASE</spring.version>
+        <hibernate.version>4.2.7.Final</hibernate.version>
+        <hibernate-validator.version>4.1.0.Final</hibernate-validator.version>
         <swagger.version>1.5.16</swagger.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -29,6 +32,611 @@
 
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- SADE -->
+            <dependency>
+                <!-- TODO: generic-common is needed for fi.vm.sade.authentication.business.service.Authorizer
+                           in three modules, and by security-context-backend.xml in all REST modules. -->
+                <groupId>fi.vm.sade.generic</groupId>
+                <artifactId>generic-common</artifactId>
+                <version>9.6-SNAPSHOT</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.jersey</groupId>
+                        <artifactId>jersey-server</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>fi.vm.sade.java-utils</groupId>
+                <artifactId>opintopolku-cas-servlet-filter</artifactId>
+                <version>0.1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>fi.vm.sade.java-utils</groupId>
+                <artifactId>java-cas</artifactId>
+                <version>0.3.1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>fi.vm.sade.organisaatio</groupId>
+                <artifactId>organisaatio-api</artifactId>
+                <version>2015-13</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>jsr311-api</artifactId>
+                        <groupId>javax.ws.rs</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.swagger</groupId>
+                        <artifactId>swagger-jaxrs</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>fi.vm.sade.tarjonta</groupId>
+                <artifactId>tarjonta-api</artifactId>
+                <version>2018-15-SNAPSHOT</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.wordnik</groupId>
+                        <artifactId>swagger-jaxrs_2.10</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.wordnik</groupId>
+                        <artifactId>swagger-annotations_2.10</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.cxf</groupId>
+                        <artifactId>cxf-bundle</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>fi.vm.sade.koodisto</groupId>
+                <artifactId>koodisto-api</artifactId>
+                <version>6.3-SNAPSHOT</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.jersey</groupId>
+                        <artifactId>jersey-server</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>fi.vm.sade</groupId>
+                <artifactId>auditlogger</artifactId>
+                <version>${auditlog.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc-portlet</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context-support</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>${spring.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-tx</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-orm</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>${spring.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-aspects</artifactId>
+                <version>${spring.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-config</artifactId>
+                <version>${spring.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-web</artifactId>
+                <version>${spring.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-cas</artifactId>
+                <version>${spring.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-ldap</artifactId>
+                <version>${spring.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-entitymanager</artifactId>
+                <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-ehcache</artifactId>
+                <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+                <version>1.0.1.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sf.ehcache</groupId>
+                <artifactId>ehcache-core</artifactId>
+                <version>2.5.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-rs-client</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-frontend-jaxws</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-transports-http</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-core</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-jaxrs</artifactId>
+                <version>${swagger.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.baev</groupId>
+                <artifactId>hamcrest-optional</artifactId>
+                <version>1.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>co.unruly</groupId>
+                <artifactId>java-8-matchers</artifactId>
+                <version>1.5</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjweaver</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjtools</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-core</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongo-java-driver</artifactId>
+                <version>3.4.2</version>
+            </dependency>
+            <dependency>
+                <groupId>cglib</groupId>
+                <artifactId>cglib-nodep</artifactId>
+                <version>2.2.2</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>0.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hsqldb</groupId>
+                <artifactId>hsqldb</artifactId>
+                <version>${hsqldb.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>de.flapdoodle.embed</groupId>
+                <artifactId>de.flapdoodle.embed.mongo</artifactId>
+                <version>${flapdoodle.embed.mongo.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <artifactId>nosqlunit-mongodb</artifactId>
+                <groupId>com.lordofthejars</groupId>
+                <version>${nosql-junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modelmapper</groupId>
+                <artifactId>modelmapper</artifactId>
+                <version>${modelmapper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>20.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.reactivex</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>1.0.11</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mysema.querydsl</groupId>
+                <artifactId>querydsl-apt</artifactId>
+                <version>${querydsl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mysema.querydsl</groupId>
+                <artifactId>querydsl-jpa</artifactId>
+                <version>${querydsl.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>cglib</groupId>
+                        <artifactId>cglib</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.6</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.6</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.5</version>
+            </dependency>
+            <dependency>
+                <groupId>javax</groupId>
+                <artifactId>javaee-web-api</artifactId>
+                <version>7.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>1.0.0.GA</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-core</artifactId>
+                <version>2.5.0-b05</version>
+            </dependency>
+            <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-api</artifactId>
+                <version>2.5.0-b05</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-locator</artifactId>
+                <version>2.5.0-b05</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-utils</artifactId>
+                <version>2.5.0-b05</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2.external</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>2.5.0-b05</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-joda</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-guava</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jasig.cas.client</groupId>
+                <artifactId>cas-client-core</artifactId>
+                <version>3.4.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jasig.cas.client</groupId>
+                <artifactId>cas-client-support-distributed-ehcache</artifactId>
+                <version>3.4.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>net.sf.ehcache</groupId>
+                        <artifactId>ehcache</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+                <version>1.0.1.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.interceptor</groupId>
+                <artifactId>jboss-interceptors-api_1.1_spec</artifactId>
+                <version>1.0.0.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>3.1.3.GA</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.18.1-GA</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>${jetty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP</artifactId>
+                <version>3.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>2.11.12</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+                <version>3.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.10</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -64,7 +672,6 @@
         <dependency>
             <groupId>fi.vm.sade.java-utils</groupId>
             <artifactId>opintopolku-cas-servlet-filter</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>fi.vm.sade</groupId>
@@ -86,7 +693,6 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.8</version>
         </dependency>
         <dependency>
             <groupId>fi.vm.sade.rajapinnat</groupId>
@@ -116,7 +722,6 @@
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
-            <version>1.0.11</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
@@ -172,7 +777,6 @@
         <dependency>
             <groupId>fi.vm.sade.tarjonta</groupId>
             <artifactId>tarjonta-api</artifactId>
-            <version>2018-15-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -204,7 +808,6 @@
         <dependency>
             <groupId>fi.vm.sade.koodisto</groupId>
             <artifactId>koodisto-api</artifactId>
-            <version>6.3-SNAPSHOT</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -227,37 +830,30 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
-            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>fi.vm.sade.organisaatio</groupId>
             <artifactId>organisaatio-api</artifactId>
-            <version>2015-13</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -296,8 +892,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <!--version>18.0</version-->
-            <version>20.0</version>
             <scope>compile</scope>
         </dependency>
         <!-- Internal -->
@@ -358,48 +952,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-core</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>${cxf.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>jaxb-impl</artifactId>
-                    <groupId>com.sun.xml.bind</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
-            <version>${cxf.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>spring-web</artifactId>
-                    <groupId>org.springframework</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>spring-beans</artifactId>
-                    <groupId>org.springframework</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>${cxf.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>spring-web</artifactId>
-                    <groupId>org.springframework</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>spring-beans</artifactId>
-                    <groupId>org.springframework</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
@@ -483,7 +1047,6 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -607,7 +1170,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.7</version>
         </dependency>
 
         <!-- spring security -->
@@ -684,7 +1246,6 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.1.0.Final</version>
             <exclusions>
                 <exclusion>
                     <artifactId>validation-api</artifactId>
@@ -695,13 +1256,11 @@
         <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache-core</artifactId>
-            <version>2.5.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
-            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -719,8 +1278,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -955,6 +1512,27 @@ buildTtime=${maven.build.timestamp}
                         </resource>
                     </webResources>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[1.8,)</version>
+                                </requireJavaVersion>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
             <dependency>
                 <groupId>io.reactivex</groupId>
                 <artifactId>rxjava</artifactId>
-                <version>1.0.11</version>
+                <version>1.3.8</version>
             </dependency>
             <dependency>
                 <groupId>com.mysema.querydsl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -402,9 +402,9 @@
                 <version>20.0</version>
             </dependency>
             <dependency>
-                <groupId>io.reactivex</groupId>
+                <groupId>io.reactivex.rxjava2</groupId>
                 <artifactId>rxjava</artifactId>
-                <version>1.3.8</version>
+                <version>2.2.5</version>
             </dependency>
             <dependency>
                 <groupId>com.mysema.querydsl</groupId>
@@ -720,7 +720,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.reactivex</groupId>
+            <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
         </dependency>
         <dependency>
@@ -1349,12 +1349,18 @@
         <dependency>
             <groupId>fi.vm.sade.valintaperusteet</groupId>
             <artifactId>sharedutils</artifactId>
-            <version>5.2-SNAPSHOT</version>
+            <version>5.3-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.reactivex</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>fi.vm.sade.valintaperusteet</groupId>
             <artifactId>sharedutils</artifactId>
-            <version>5.2-SNAPSHOT</version>
+            <version>5.3-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/fi/vm/sade/valinta/kooste/erillishaku/resource/ErillishakuResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/erillishaku/resource/ErillishakuResource.java
@@ -4,7 +4,6 @@ import static fi.vm.sade.valinta.kooste.AuthorizationUtil.createAuditSession;
 import static fi.vm.sade.valinta.kooste.proxy.resource.erillishaku.util.PseudoSatunnainenOID.oidHaustaJaHakukohteesta;
 import static fi.vm.sade.valinta.kooste.proxy.resource.erillishaku.util.PseudoSatunnainenOID.trimToNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static rx.observables.BlockingObservable.from;
 
 import fi.vm.sade.authentication.business.service.Authorizer;
 import fi.vm.sade.sharedutils.AuditLog;
@@ -191,6 +190,6 @@ public class ErillishakuResource {
     }
 
     private String findTarjoajaOid(@QueryParam("hakukohdeOid") String hakukohdeOid) {
-        return HakukohdeHelper.tarjoajaOid(from(tarjontaResource.haeHakukohde(hakukohdeOid).timeout(30, SECONDS)).first());
+        return HakukohdeHelper.tarjoajaOid(tarjontaResource.haeHakukohde(hakukohdeOid).timeout(30, SECONDS).blockingFirst());
     }
 }

--- a/src/main/java/fi/vm/sade/valinta/kooste/erillishaku/service/impl/ErillishaunVientiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/erillishaku/service/impl/ErillishaunVientiService.java
@@ -28,15 +28,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import rx.Observable;
-import rx.schedulers.Schedulers;
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static rx.Observable.zip;
+import static io.reactivex.Observable.zip;
 
 @Service
 public class ErillishaunVientiService {

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/UrlConfiguredResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/UrlConfiguredResource.java
@@ -12,7 +12,7 @@ import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ataru/AtaruAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ataru/AtaruAsyncResource.java
@@ -1,7 +1,7 @@
 package fi.vm.sade.valinta.kooste.external.resource.ataru;
 
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ataru/impl/AtaruAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ataru/impl/AtaruAsyncResourceImpl.java
@@ -2,6 +2,7 @@ package fi.vm.sade.valinta.kooste.external.resource.ataru.impl;
 
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
+
 import fi.vm.sade.valinta.kooste.external.resource.UrlConfiguredResource;
 import fi.vm.sade.valinta.kooste.external.resource.ataru.AtaruAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.ataru.dto.AtaruHakemus;
@@ -12,6 +13,7 @@ import fi.vm.sade.valinta.kooste.external.resource.oppijanumerorekisteri.dto.Hen
 import fi.vm.sade.valinta.kooste.external.resource.oppijanumerorekisteri.dto.KansalaisuusDto;
 import fi.vm.sade.valinta.kooste.util.AtaruHakemusWrapper;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
+import io.reactivex.Observable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.slf4j.Logger;
@@ -19,11 +21,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import rx.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -125,7 +129,7 @@ public class AtaruAsyncResourceImpl extends UrlConfiguredResource implements Ata
                         .distinct()
                         .map(koodiArvo -> koodistoCachedAsyncResource.maatjavaltiot2ToMaatjavaltiot1("maatjavaltiot2_" + koodiArvo)
                                 .map(koodi -> Pair.of(koodiArvo, koodi)))
-                        .collect(Collectors.toList())).toMap(Pair::getLeft, Pair::getRight);
+                        .collect(Collectors.toList())).toMap(Pair::getLeft, Pair::getRight).toObservable();
     }
 
     @Override

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/dokumentti/DokumenttiAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/dokumentti/DokumenttiAsyncResource.java
@@ -1,6 +1,6 @@
 package fi.vm.sade.valinta.kooste.external.resource.dokumentti;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.io.InputStream;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/dokumentti/impl/DokumenttiAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/dokumentti/impl/DokumenttiAsyncResourceImpl.java
@@ -4,7 +4,7 @@ import com.google.common.reflect.TypeToken;
 
 import fi.vm.sade.valinta.kooste.external.resource.UrlConfiguredResource;
 import fi.vm.sade.valinta.kooste.external.resource.dokumentti.DokumenttiAsyncResource;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/hakuapp/ApplicationAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/hakuapp/ApplicationAsyncResource.java
@@ -2,7 +2,7 @@ package fi.vm.sade.valinta.kooste.external.resource.hakuapp;
 
 import fi.vm.sade.valinta.kooste.external.resource.hakuapp.dto.HakemusPrototyyppi;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.Arrays;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koodisto/KoodistoAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koodisto/KoodistoAsyncResource.java
@@ -1,7 +1,7 @@
 package fi.vm.sade.valinta.kooste.external.resource.koodisto;
 
 import fi.vm.sade.valinta.kooste.external.resource.koodisto.dto.Koodi;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koodisto/KoodistoCachedAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koodisto/KoodistoCachedAsyncResource.java
@@ -7,11 +7,11 @@ import com.google.common.cache.CacheBuilder;
 import fi.vm.sade.valinta.kooste.external.resource.koodisto.dto.Koodi;
 import fi.vm.sade.valinta.kooste.external.resource.koodisto.dto.Metadata;
 import fi.vm.sade.valinta.kooste.util.KieliUtil;
+import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import rx.Observable;
 
 import java.util.List;
 import java.util.Map;
@@ -77,8 +77,7 @@ public class KoodistoCachedAsyncResource {
             return koodistoCache.get(koodistoUri, () -> konversio(koodistoAsyncResource
                 .haeKoodisto(koodistoUri)
                 .timeout(1, MINUTES)
-                .toBlocking()
-                .first()));
+                .blockingFirst()));
         } catch (Exception e) {
             LOG.error("Koodistosta luku epäonnistui:", e);
             throw new RuntimeException(e);

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koodisto/impl/KoodistoAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koodisto/impl/KoodistoAsyncResourceImpl.java
@@ -6,7 +6,7 @@ import fi.vm.sade.valinta.kooste.external.resource.koodisto.dto.Koodi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.GenericType;
 import java.util.List;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ohjausparametrit/OhjausparametritAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ohjausparametrit/OhjausparametritAsyncResource.java
@@ -1,7 +1,7 @@
 package fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit;
 
 import fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.dto.ParametritDTO;
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface OhjausparametritAsyncResource {
     Observable<ParametritDTO> haeHaunOhjausparametrit(String hakuOid);

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ohjausparametrit/impl/OhjausparametritAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/ohjausparametrit/impl/OhjausparametritAsyncResourceImpl.java
@@ -1,13 +1,13 @@
 package fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.impl;
 
-import fi.vm.sade.valinta.sharedutils.http.HttpExceptionWithResponse;
 import fi.vm.sade.valinta.kooste.external.resource.UrlConfiguredResource;
 import fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.OhjausparametritAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.dto.ParametritDTO;
+import fi.vm.sade.valinta.sharedutils.http.HttpExceptionWithResponse;
+import io.reactivex.Observable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import rx.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/oppijantunnistus/OppijantunnistusAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/oppijantunnistus/OppijantunnistusAsyncResource.java
@@ -2,7 +2,7 @@ package fi.vm.sade.valinta.kooste.external.resource.oppijantunnistus;
 
 import fi.vm.sade.valinta.kooste.external.resource.oppijantunnistus.dto.TokensRequest;
 import fi.vm.sade.valinta.kooste.external.resource.oppijantunnistus.dto.TokensResponse;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/oppijantunnistus/impl/OppijantunnistusAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/oppijantunnistus/impl/OppijantunnistusAsyncResourceImpl.java
@@ -1,15 +1,14 @@
 package fi.vm.sade.valinta.kooste.external.resource.oppijantunnistus.impl;
 
 import com.google.common.reflect.TypeToken;
+
 import fi.vm.sade.valinta.kooste.external.resource.UrlConfiguredResource;
 import fi.vm.sade.valinta.kooste.external.resource.oppijantunnistus.OppijantunnistusAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.oppijantunnistus.dto.TokensRequest;
 import fi.vm.sade.valinta.kooste.external.resource.oppijantunnistus.dto.TokensResponse;
-import fi.vm.sade.valinta.kooste.url.UrlConfiguration;
+import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import rx.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/oppijanumerorekisteri/OppijanumerorekisteriAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/oppijanumerorekisteri/OppijanumerorekisteriAsyncResource.java
@@ -2,7 +2,7 @@ package fi.vm.sade.valinta.kooste.external.resource.oppijanumerorekisteri;
 
 import fi.vm.sade.valinta.kooste.external.resource.oppijanumerorekisteri.dto.HenkiloCreateDTO;
 import fi.vm.sade.valinta.kooste.external.resource.oppijanumerorekisteri.dto.HenkiloPerustietoDto;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/organisaatio/OrganisaatioAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/organisaatio/OrganisaatioAsyncResource.java
@@ -2,7 +2,7 @@ package fi.vm.sade.valinta.kooste.external.resource.organisaatio;
 
 import fi.vm.sade.organisaatio.resource.dto.HakutoimistoDTO;
 import fi.vm.sade.valinta.kooste.external.resource.organisaatio.dto.OrganisaatioTyyppiHierarkia;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.Optional;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/organisaatio/impl/OrganisaatioAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/organisaatio/impl/OrganisaatioAsyncResourceImpl.java
@@ -6,14 +6,15 @@ import fi.vm.sade.organisaatio.resource.dto.HakutoimistoDTO;
 import fi.vm.sade.valinta.kooste.external.resource.UrlConfiguredResource;
 import fi.vm.sade.valinta.kooste.external.resource.organisaatio.OrganisaatioAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.organisaatio.dto.OrganisaatioTyyppiHierarkia;
+import io.reactivex.Observable;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import rx.Observable;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -25,6 +26,7 @@ import java.util.function.Function;
  */
 @Service
 public class OrganisaatioAsyncResourceImpl extends UrlConfiguredResource implements OrganisaatioAsyncResource {
+    private static final HakutoimistoDTO HAKUTOIMISTO_NULL = new HakutoimistoDTO(null, Collections.emptyMap());
     private final Logger LOG = LoggerFactory.getLogger(getClass());
 
     public OrganisaatioAsyncResourceImpl() {
@@ -63,8 +65,13 @@ public class OrganisaatioAsyncResourceImpl extends UrlConfiguredResource impleme
                 .onErrorReturn(
                         exception -> {
                             LOG.error("Unable to fetch hakutoimisto for organisaatioId={}",organisaatioId);
-                            return null;
+                            return HAKUTOIMISTO_NULL;
                         })
-                .map(m -> Optional.ofNullable(m));
+                .map(m -> {
+                    if (m == null || m == HAKUTOIMISTO_NULL) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(m);
+                });
     }
 }

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/DokumentinSeurantaAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/DokumentinSeurantaAsyncResource.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import fi.vm.sade.valinta.seuranta.dto.DokumenttiDto;
 import fi.vm.sade.valinta.seuranta.dto.VirheilmoitusDto;
-import rx.Observable;
+import io.reactivex.Observable;
 
 public interface DokumentinSeurantaAsyncResource {
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/LaskentaSeurantaAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/LaskentaSeurantaAsyncResource.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 public interface LaskentaSeurantaAsyncResource {
 
-    Observable<String> otaSeuraavaLaskentaTyonAlle();
+    Observable<Optional<String>> otaSeuraavaLaskentaTyonAlle();
 
     Observable<LaskentaDto> laskenta(String uuid);
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/LaskentaSeurantaAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/LaskentaSeurantaAsyncResource.java
@@ -7,7 +7,7 @@ import fi.vm.sade.valinta.seuranta.dto.IlmoitusDto;
 import fi.vm.sade.valinta.seuranta.dto.LaskentaDto;
 import fi.vm.sade.valinta.seuranta.dto.LaskentaTila;
 import fi.vm.sade.valinta.seuranta.dto.TunnisteDto;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.List;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/DokumentinSeurantaAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/DokumentinSeurantaAsyncResourceImpl.java
@@ -8,7 +8,7 @@ import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/LaskentaSeurantaAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/LaskentaSeurantaAsyncResourceImpl.java
@@ -39,10 +39,10 @@ public class LaskentaSeurantaAsyncResourceImpl extends UrlConfiguredResource imp
     }
 
     @Override
-    public Observable<String> otaSeuraavaLaskentaTyonAlle() {
+    public Observable<Optional<String>> otaSeuraavaLaskentaTyonAlle() {
         return getAsObservableLazily(
             getUrl("seuranta-service.seuranta.laskenta.otaseuraavalaskentatyonalle"),
-            String.class,
+            Optional.class,
             webClient -> webClient.accept(MediaType.TEXT_PLAIN_TYPE));
     }
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/LaskentaSeurantaAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/LaskentaSeurantaAsyncResourceImpl.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/LaskentaSeurantaAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/seuranta/impl/LaskentaSeurantaAsyncResourceImpl.java
@@ -11,13 +11,14 @@ import fi.vm.sade.valinta.seuranta.dto.IlmoitusDto;
 import fi.vm.sade.valinta.seuranta.dto.LaskentaDto;
 import fi.vm.sade.valinta.seuranta.dto.LaskentaTila;
 import fi.vm.sade.valinta.seuranta.dto.TunnisteDto;
+import io.reactivex.Observable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -25,6 +26,7 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 
 @Service
@@ -40,9 +42,12 @@ public class LaskentaSeurantaAsyncResourceImpl extends UrlConfiguredResource imp
 
     @Override
     public Observable<Optional<String>> otaSeuraavaLaskentaTyonAlle() {
-        return getAsObservableLazily(
-            getUrl("seuranta-service.seuranta.laskenta.otaseuraavalaskentatyonalle"),
-            Optional.class,
+        Function<String, Optional<String>> extractor = response ->
+            StringUtils.isBlank(response) ?
+                Optional.empty() :
+                Optional.of(response);
+        return getAsObservableLazily(getUrl("seuranta-service.seuranta.laskenta.otaseuraavalaskentatyonalle"),
+            extractor,
             webClient -> webClient.accept(MediaType.TEXT_PLAIN_TYPE));
     }
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/sijoittelu/impl/SijoitteleAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/sijoittelu/impl/SijoitteleAsyncResourceImpl.java
@@ -38,8 +38,7 @@ public class SijoitteleAsyncResourceImpl extends UrlConfiguredResource implement
         try {
             sijoitteluajoId = this.<Long>getAsObservableLazily(luontiUrl, Long.class, client -> client.accept(MediaType.WILDCARD_TYPE))
                 .timeout(30, SECONDS)
-                .toBlocking()
-                .first();
+                .blockingFirst();
         } catch (Exception e) {
             LOGGER.info(String.format("(Haku %s) sijoittelun rajapintakutsu epäonnistui", hakuOid), e);
         }
@@ -65,8 +64,7 @@ public class SijoitteleAsyncResourceImpl extends UrlConfiguredResource implement
             try {
                 status = this.<String>getAsObservableLazily(pollingUrl, String.class, webClient -> webClient.accept(MediaType.WILDCARD_TYPE))
                     .timeout(15, SECONDS)
-                    .toBlocking()
-                    .first();
+                    .blockingFirst();
                 LOGGER.info("Saatiin ajontila-rajapinnalta palautusarvo {}", status);
                 if (SijoitteluajonTila.VALMIS.toString().equals(status)) {
                     LOGGER.info("#### Sijoittelu {} haulle {} on valmistunut", sijoitteluajoId, hakuOid);

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/suoritusrekisteri/SuoritusrekisteriAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/suoritusrekisteri/SuoritusrekisteriAsyncResource.java
@@ -3,7 +3,7 @@ package fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri;
 import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.dto.Arvosana;
 import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.dto.Oppija;
 import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.dto.Suoritus;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ public interface SuoritusrekisteriAsyncResource {
 
     Observable<Arvosana> updateExistingArvosana(String arvosanaId, Arvosana arvosanaWithUpdatedValues);
 
-    Observable<Void> deleteSuoritus(String suoritusId);
+    Observable<String> deleteSuoritus(String suoritusId);
 
-    Observable<Void> deleteArvosana(String arvosanaId);
+    Observable<String> deleteArvosana(String arvosanaId);
 }

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/tarjonta/TarjontaAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/tarjonta/TarjontaAsyncResource.java
@@ -3,7 +3,7 @@ package fi.vm.sade.valinta.kooste.external.resource.tarjonta;
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakuV1RDTO;
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakukohdeV1RDTO;
 import fi.vm.sade.valinta.kooste.external.resource.tarjonta.dto.ResultOrganization;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/tarjonta/impl/TarjontaAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/tarjonta/impl/TarjontaAsyncResourceImpl.java
@@ -24,7 +24,7 @@ import fi.vm.sade.valinta.kooste.external.resource.tarjonta.dto.ResultTulos;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -105,13 +105,13 @@ class TarjontaAsyncResourceImplHelper {
     static Observable<Map<String, List<String>>> resultSearchToHakukohdeRyhmaMap(Observable<ResultSearch> observable) {
         return observable.map(ResultSearch::getResult)
                 .map(ResultTulos::getTulokset)
-                .flatMap(Observable::from)
+                .flatMap(Observable::fromIterable)
                 .map(ResultOrganization::getTulokset)
-                .flatMap(Observable::from)
+                .flatMap(Observable::fromIterable)
                 .map((ResultHakukohde s) -> new ImmutablePair<>(
                         s.getOid(),
                         getRyhmaList(s)))
-                .toMap(Pair::getKey, Pair::getValue);
+                .toMap(Pair::getKey, Pair::getValue).toObservable();
     }
 
     private static List<String> getRyhmaList (ResultHakukohde hk) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/ValintalaskentaAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/ValintalaskentaAsyncResource.java
@@ -4,7 +4,7 @@ import fi.vm.sade.valintalaskenta.domain.dto.JonoDto;
 import fi.vm.sade.valintalaskenta.domain.dto.LaskeDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.ValinnanvaiheDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.ValintatietoValinnanvaiheDTO;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/ValintalaskentaValintakoeAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/ValintalaskentaValintakoeAsyncResource.java
@@ -2,7 +2,7 @@ package fi.vm.sade.valinta.kooste.external.resource.valintalaskenta;
 
 import fi.vm.sade.valintalaskenta.domain.dto.valintakoe.ValintakoeOsallistuminenDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.HakemusOsallistuminenDTO;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/impl/ValintalaskentaAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/impl/ValintalaskentaAsyncResourceImpl.java
@@ -14,7 +14,7 @@ import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.ValintatietoValinnanva
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/impl/ValintalaskentaValintakoeAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintalaskenta/impl/ValintalaskentaValintakoeAsyncResourceImpl.java
@@ -8,7 +8,7 @@ import fi.vm.sade.valinta.kooste.external.resource.valintalaskenta.Valintalasken
 import fi.vm.sade.valintalaskenta.domain.dto.valintakoe.ValintakoeOsallistuminenDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.HakemusOsallistuminenDTO;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintaperusteet/ValintaperusteetAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintaperusteet/ValintaperusteetAsyncResource.java
@@ -1,7 +1,7 @@
 package fi.vm.sade.valinta.kooste.external.resource.valintaperusteet;
 
 import fi.vm.sade.service.valintaperusteet.dto.*;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.Collection;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintaperusteet/impl/ValintaperusteetAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintaperusteet/impl/ValintaperusteetAsyncResourceImpl.java
@@ -9,7 +9,7 @@ import fi.vm.sade.valinta.kooste.external.resource.valintaperusteet.Valintaperus
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintapiste/ValintapisteAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintapiste/ValintapisteAsyncResource.java
@@ -3,9 +3,8 @@ package fi.vm.sade.valinta.kooste.external.resource.valintapiste;
 import fi.vm.sade.valinta.kooste.external.resource.valintapiste.dto.PisteetWithLastModified;
 import fi.vm.sade.valinta.kooste.external.resource.valintapiste.dto.Valintapisteet;
 import fi.vm.sade.valinta.kooste.external.resource.valintatulosservice.dto.AuditSession;
-import rx.Observable;
+import io.reactivex.Observable;
 
-import javax.ws.rs.core.Response;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintapiste/ValintapisteAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintapiste/ValintapisteAsyncResourceImpl.java
@@ -11,7 +11,7 @@ import org.apache.cxf.jaxrs.impl.ResponseImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintatulosservice/ValintaTulosServiceAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintatulosservice/ValintaTulosServiceAsyncResource.java
@@ -15,7 +15,7 @@ import fi.vm.sade.valinta.kooste.proxy.resource.valintatulosservice.TilaHakijall
 import fi.vm.sade.valinta.kooste.proxy.resource.valintatulosservice.VastaanottoAikarajaMennytDTO;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 import java.util.Set;
@@ -33,7 +33,7 @@ public interface ValintaTulosServiceAsyncResource {
 
     Observable<List<Lukuvuosimaksu>> fetchLukuvuosimaksut(String hakukohdeOid, AuditSession session);
 
-    Observable<Void> saveLukuvuosimaksut(String hakukohdeOid, AuditSession session, List<LukuvuosimaksuMuutos> muutokset);
+    Observable<String> saveLukuvuosimaksut(String hakukohdeOid, AuditSession session, List<LukuvuosimaksuMuutos> muutokset);
 
     Observable<List<Valintatulos>> findValintatuloksetIlmanHakijanTilaa(String hakuOid, String hakukohdeOid);
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintatulosservice/impl/ValintaTulosServiceAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/valintatulosservice/impl/ValintaTulosServiceAsyncResourceImpl.java
@@ -31,7 +31,7 @@ import fi.vm.sade.valinta.kooste.proxy.resource.valintatulosservice.VastaanottoA
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
@@ -148,7 +148,7 @@ public class ValintaTulosServiceAsyncResourceImpl extends UrlConfiguredResource 
     }
 
     @Override
-    public Observable<Void> saveLukuvuosimaksut(String hakukohdeOid, AuditSession session, List<LukuvuosimaksuMuutos> muutokset) {
+    public Observable<String> saveLukuvuosimaksut(String hakukohdeOid, AuditSession session, List<LukuvuosimaksuMuutos> muutokset) {
         return postAsObservableLazily(getUrl("valinta-tulos-service.virkailija.valintatulos.lukuvuosimaksu", "write", hakukohdeOid),
                 Void.class,
                 Entity.json(of("lukuvuosimaksuMuutokset", muutokset, "auditSession", session)));

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/RyhmasahkopostiAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/RyhmasahkopostiAsyncResource.java
@@ -1,6 +1,6 @@
 package fi.vm.sade.valinta.kooste.external.resource.viestintapalvelu;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Optional;
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/ViestintapalveluAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/ViestintapalveluAsyncResource.java
@@ -6,7 +6,7 @@ import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.letter.LetterBatch;
 import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.letter.LetterBatchStatusDto;
 import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.letter.LetterResponse;
 import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.letter.TemplateHistory;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.time.Duration;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/impl/RyhmasahkopostiAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/impl/RyhmasahkopostiAsyncResourceImpl.java
@@ -7,7 +7,7 @@ import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/impl/ViestintapalveluAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/viestintapalvelu/impl/ViestintapalveluAsyncResourceImpl.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;

--- a/src/main/java/fi/vm/sade/valinta/kooste/hakemukset/service/ValinnanvaiheenValintakoekutsutService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/hakemukset/service/ValinnanvaiheenValintakoekutsutService.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -69,11 +69,11 @@ public class ValinnanvaiheenValintakoekutsutService {
                             if (haku.getAtaruLomakeAvain() == null) {
                                 return applicationAsyncResource.getApplicationsByOidsWithPOST(hakuOid, hakukohdeOidit);
                             } else {
-                                return Observable.from(hakukohdeOidit)
+                                return Observable.fromIterable(hakukohdeOidit)
                                         .flatMap(hakukohdeOid -> ataruAsyncResource.getApplicationsByHakukohde(hakukohdeOid)
-                                                .flatMap(Observable::from))
+                                                .flatMap(Observable::fromIterable))
                                         .distinct(HakemusWrapper::getOid)
-                                        .toList();
+                                        .toList().toObservable();
                             }
                         }).subscribe(
                                 hakemukset -> handleApplicationsResponse(hakemukset, authorityCheck, successHandler, exceptionHandler, hakukohdeOidit),

--- a/src/main/java/fi/vm/sade/valinta/kooste/parametrit/service/HakuParametritService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/parametrit/service/HakuParametritService.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -37,11 +37,10 @@ public class HakuParametritService {
     public ParametritParser getParametritForHaku(String hakuOid) {
         try {
             Observable<ParametritDTO> parametritDTOObservable = haunOhjausParametritCache.get(hakuOid,
-                    () -> ohjausparametritAsyncResource.haeHaunOhjausparametrit(hakuOid).single());
+                    () -> ohjausparametritAsyncResource.haeHaunOhjausparametrit(hakuOid).singleElement().toObservable());
             ParametritDTO paramDto = parametritDTOObservable
                 .timeout(30, SECONDS)
-                .toBlocking()
-                .single();
+                .blockingSingle();
             return new ParametritParser(paramDto, rootOrganisaatioOid);
         } catch (Exception e) {
             LOG.error(String.format("Error querying ParametritDTO for haku %s", hakuOid), e);

--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/resource/PistesyottoResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/resource/PistesyottoResource.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
@@ -301,7 +301,7 @@ public class PistesyottoResource {
                 "ROLE_APP_HAKEMUS_LISATIETOCRUD"
         )).flatMap(authorityCheck -> {
             if (authorityCheck.test(hakukohdeOid)) {
-                return Observable.just(null);
+                return Observable.just("OK");
             }
             String msg = String.format(
                     "Käyttäjällä %s ei ole oikeuksia käsitellä hakukohteen %s pistetietoja",
@@ -324,7 +324,7 @@ public class PistesyottoResource {
                             .filter(oid -> !hakukohteenHakemusOidit.contains(oid))
                             .collect(Collectors.toSet());
                     if (eiHakukohteeseenHakeneet.isEmpty()) {
-                        return Observable.just(null);
+                        return Observable.just("OK");
                     }
                     return Observable.error(new ForbiddenException(String.format(
                             "Käyttäjällä %s ei ole oikeuksia käsitellä hakemuksien %s pistetietoja, koska niillä ei ole haettu hakukohteeseen %s",
@@ -423,7 +423,7 @@ public class PistesyottoResource {
                     "ROLE_APP_HAKEMUS_LISATIETOCRUD"
             )).flatMap(authorityCheck -> {
                 if (authorityCheck.test(hakukohdeOid)) {
-                    return Observable.just(null);
+                    return Observable.just("OK");
                 }
                 String msg = String.format(
                         "Käyttäjällä %s ei ole oikeuksia käsitellä hakukohteen %s pistetietoja",

--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.math.BigDecimal;
 import java.util.*;

--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoKoosteService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoKoosteService.java
@@ -1,15 +1,13 @@
 package fi.vm.sade.valinta.kooste.pistesyotto.service;
 
-import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteDTO;
-import fi.vm.sade.valinta.kooste.external.resource.ataru.AtaruAsyncResource;
-import fi.vm.sade.sharedutils.ValintaperusteetOperation;
 import static java.util.Collections.singletonList;
 
+import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteDTO;
 import fi.vm.sade.sharedutils.ValintaperusteetOperation;
+import fi.vm.sade.valinta.kooste.external.resource.ataru.AtaruAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.hakuapp.ApplicationAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.hakuapp.dto.ApplicationAdditionalDataDTO;
 import fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.OhjausparametritAsyncResource;
-import fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.dto.ParametritDTO;
 import fi.vm.sade.valinta.kooste.external.resource.organisaatio.OrganisaatioAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.SuoritusrekisteriAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.dto.Oppija;
@@ -25,19 +23,23 @@ import fi.vm.sade.valinta.kooste.pistesyotto.dto.HenkiloValilehtiDTO;
 import fi.vm.sade.valinta.kooste.pistesyotto.dto.PistesyottoValilehtiDTO;
 import fi.vm.sade.valinta.kooste.pistesyotto.dto.TuontiErrorDTO;
 import fi.vm.sade.valinta.kooste.pistesyotto.excel.PistesyottoExcel;
-import fi.vm.sade.valinta.kooste.util.Converter;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
-import fi.vm.sade.valintalaskenta.domain.dto.HakemusDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintakoe.HakutoiveDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintakoe.ValintakoeOsallistuminenDTO;
 import fi.vm.sade.valintalaskenta.domain.valintakoe.Osallistuminen;
+import io.reactivex.Observable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import rx.Observable;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -102,7 +104,7 @@ public class PistesyottoKoosteService extends AbstractPistesyottoKoosteService {
                         .map(hakukohdeOid -> valintaperusteetAsyncResource.findAvaimet(hakukohdeOid)
                                 .map(valintaperusteet -> Pair.of(hakukohdeOid, valintaperusteet)))
                         .collect(Collectors.toList())
-        ).toList();
+        ).toList().toObservable();
     }
 
     private Observable<HakemusWrapper> getHakemus(String hakemusOid) {
@@ -212,7 +214,7 @@ public class PistesyottoKoosteService extends AbstractPistesyottoKoosteService {
                 }).collect(Collectors.toList()));
                 return errors;
             }
-        }).lastOrDefault(null);
+        }).last(Collections.emptySet()).toObservable();
     }
 
     public Observable<Set<TuontiErrorDTO>> tallennaKoostetutPistetiedot(String hakuOid,

--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoTuontiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoTuontiService.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -136,7 +136,7 @@ public class PistesyottoTuontiService extends AbstractPistesyottoKoosteService {
 
                     if (uudetPistetiedot.isEmpty()) {
                         LOG.info("Pistesyötössä hakukohteeseen {} ei yhtäkään muuttunutta tietoa tallennettavaksi", hakukohdeOid);
-                        return Observable.just(null);
+                        return Observable.just(Collections.emptySet());
                     } else {
                         LOG.info("Pistesyötössä hakukohteeseen {} muuttunutta {} tietoa tallennettavaksi", hakukohdeOid, uudetPistetiedot.size());
                         Observable<Set<String>> failedPisteet = tallennaKoostetutPistetiedot(hakuOid, hakukohdeOid, ifUnmodifiedSince, uudetPistetiedot,

--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoVientiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoVientiService.java
@@ -20,7 +20,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;

--- a/src/main/java/fi/vm/sade/valinta/kooste/proxy/resource/jonotsijoittelussa/JonotSijoittelussaProxyResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/proxy/resource/jonotsijoittelussa/JonotSijoittelussaProxyResource.java
@@ -1,5 +1,7 @@
 package fi.vm.sade.valinta.kooste.proxy.resource.jonotsijoittelussa;
 
+import com.google.gson.Gson;
+
 import fi.vm.sade.service.valintaperusteet.dto.ValintatapajonoDTO;
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakuV1RDTO;
 import fi.vm.sade.valinta.kooste.external.resource.tarjonta.TarjontaAsyncResource;
@@ -7,16 +9,15 @@ import fi.vm.sade.valinta.kooste.external.resource.valintalaskenta.Valintalasken
 import fi.vm.sade.valinta.kooste.external.resource.valintaperusteet.ValintaperusteetAsyncResource;
 import fi.vm.sade.valinta.kooste.proxy.resource.jonotsijoittelussa.dto.HakukohdePair;
 import fi.vm.sade.valinta.kooste.proxy.resource.jonotsijoittelussa.dto.Jono;
-import fi.vm.sade.valinta.kooste.proxy.resource.jonotsijoittelussa.dto.JonoPair;
 import fi.vm.sade.valinta.kooste.proxy.resource.jonotsijoittelussa.util.JonoUtil;
 import fi.vm.sade.valintalaskenta.domain.dto.JonoDto;
+import io.reactivex.Observable;
 import io.swagger.annotations.Api;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import rx.Observable;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -25,16 +26,11 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Collections.emptyList;
-
-import com.google.gson.Gson;
 
 @Controller("JonotSijoittelussaProxyResource")
 @Path("/proxy/jonotsijoittelussa")

--- a/src/main/java/fi/vm/sade/valinta/kooste/proxy/resource/viestintapalvelu/ViestintapalveluProxyResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/proxy/resource/viestintapalvelu/ViestintapalveluProxyResource.java
@@ -1,7 +1,7 @@
 package fi.vm.sade.valinta.kooste.proxy.resource.viestintapalvelu;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static rx.Observable.combineLatest;
+import static io.reactivex.Observable.combineLatest;
 import com.google.common.collect.ImmutableMap;
 
 import fi.vm.sade.valinta.kooste.external.resource.viestintapalvelu.RyhmasahkopostiAsyncResource;
@@ -12,8 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import rx.Observable;
-import rx.observables.BlockingObservable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -69,8 +68,7 @@ public class ViestintapalveluProxyResource {
         if (countDto.letterBatchId == null) {
             return countDto;
         }
-        Optional<Long> groupEmailId = BlockingObservable.from(
-            ryhmasahkopostiAsyncResource.haeRyhmasahkopostiIdByLetterObservable(countDto.letterBatchId).timeout(5, MINUTES)).first();
+        Optional<Long> groupEmailId = ryhmasahkopostiAsyncResource.haeRyhmasahkopostiIdByLetterObservable(countDto.letterBatchId).timeout(5, MINUTES).blockingFirst();
         return groupEmailId.map(aLong ->
             new LetterBatchCountDto(
                 countDto.letterBatchId,

--- a/src/main/java/fi/vm/sade/valinta/kooste/sijoitteluntulos/service/HyvaksymiskirjeetHaulleHakukohteittain.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/sijoitteluntulos/service/HyvaksymiskirjeetHaulleHakukohteittain.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/fi/vm/sade/valinta/kooste/sijoitteluntulos/service/HyvaksymiskirjeetKokoHaulleService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/sijoitteluntulos/service/HyvaksymiskirjeetKokoHaulleService.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/fi/vm/sade/valinta/kooste/tarjonta/sync/impl/TarjontaSyncServiceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/tarjonta/sync/impl/TarjontaSyncServiceImpl.java
@@ -1,7 +1,6 @@
 package fi.vm.sade.valinta.kooste.tarjonta.sync.impl;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static rx.observables.BlockingObservable.from;
 
 import fi.vm.sade.valinta.kooste.external.resource.tarjonta.TarjontaAsyncResource;
 import fi.vm.sade.valinta.kooste.hakuimport.route.HakuImportRoute;
@@ -25,7 +24,7 @@ public class TarjontaSyncServiceImpl implements TarjontaSyncService {
     HakuImportRoute hakuImportAktivointiRoute;
 
     public void syncHakukohteetFromTarjonta() {
-        Set<String> hakuOids = from(tarjontaAsyncResource.findHakuOidsForAutosyncTarjonta().timeout(1, MINUTES)).first();
+        Set<String> hakuOids = tarjontaAsyncResource.findHakuOidsForAutosyncTarjonta().timeout(1, MINUTES).blockingFirst();
         if (hakuOids != null) {
             for (String hakuOid : hakuOids) {
                 LOG.info("Starting synchronization for haku: " + hakuOid);

--- a/src/main/java/fi/vm/sade/valinta/kooste/util/PoikkeusKasittelijaSovitin.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/util/PoikkeusKasittelijaSovitin.java
@@ -2,18 +2,11 @@ package fi.vm.sade.valinta.kooste.util;
 
 import java.util.function.Consumer;
 
-import rx.functions.Action1;
-
-public class PoikkeusKasittelijaSovitin implements Consumer<Throwable>, Action1<Throwable> {
+public class PoikkeusKasittelijaSovitin implements Consumer<Throwable>, io.reactivex.functions.Consumer<Throwable> {
     private Consumer<Throwable> kasittelija;
 
     public PoikkeusKasittelijaSovitin(Consumer<Throwable> kasittelija) {
         this.kasittelija = kasittelija;
-    }
-
-    @Override
-    public void call(final Throwable throwable) {
-        accept(throwable);
     }
 
     @Override

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintakokeet/AktiivistenHakemustenValintakoeResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintakokeet/AktiivistenHakemustenValintakoeResource.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorSystem.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorSystem.java
@@ -36,6 +36,7 @@ import scala.concurrent.duration.FiniteDuration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -135,15 +136,15 @@ public class LaskentaActorSystem implements ValintalaskentaKerrallaRouteValvomo,
             });
     }
 
-    private void startLaskentaIfWorkAvailable(String uuid) {
-        if (uuid == null) {
+    private void startLaskentaIfWorkAvailable(Optional<String> uuid) {
+        if (!uuid.isPresent()) {
             LOG.trace("Ei laskettavaa");
             laskennanKaynnistajaActor.tell(new NoWorkAvailable(), ActorRef.noSender());
         } else {
-            LOG.info("Luodaan ja aloitetaan Laskenta uuid:lle {}", uuid);
+            LOG.info("Luodaan ja aloitetaan Laskenta uuid:lle {}", uuid.get());
             laskentaStarter.fetchLaskentaParams(
                     laskennanKaynnistajaActor,
-                    uuid,
+                    uuid.get(),
                     (haku, params) -> startLaskentaActor(params.getLaskentaStartParams(),
                             laskentaActorFactory.createLaskentaActor(params.getLaskentaStartParams().getAuditSession(), this, haku, params))
             );

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaResurssinhakuObservable.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaResurssinhakuObservable.java
@@ -1,17 +1,16 @@
 package fi.vm.sade.valinta.kooste.valintalaskenta.actor;
 
+import static io.reactivex.Observable.range;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static rx.Observable.range;
-import static rx.Observable.timer;
 
 import fi.vm.sade.valinta.sharedutils.http.HttpExceptionWithResponse;
 import fi.vm.sade.valinta.sharedutils.http.ObservableUtil;
+import io.reactivex.Observable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rx.Observable;
-import rx.functions.Action1;
-import rx.functions.Func1;
 
 public class LaskentaResurssinhakuObservable<R> {
     private static final Logger LOG = LoggerFactory.getLogger(LaskentaResurssinhakuObservable.class);
@@ -30,7 +29,7 @@ public class LaskentaResurssinhakuObservable<R> {
         this.tunniste = tunniste;
     }
 
-    private static Func1<Observable<? extends Throwable>, Observable<?>> createRetryer(PyynnonTunniste tunniste) {
+    private static Function<Observable<? extends Throwable>, Observable<?>> createRetryer(PyynnonTunniste tunniste) {
         int maxRetries = 5;
         int secondsToWaitMultiplier = 10;
         return errors -> errors.zipWith(range(1, maxRetries+1), (n, i) -> {
@@ -44,7 +43,7 @@ public class LaskentaResurssinhakuObservable<R> {
             .flatMap(i -> i);
     }
 
-    private Action1<? super Object> resurssiOK(long startTime, PyynnonTunniste tunniste) {
+    private Consumer<? super Object> resurssiOK(long startTime, PyynnonTunniste tunniste) {
         return r -> {
             long l = System.currentTimeMillis();
             long duration = l - startTime;
@@ -52,7 +51,7 @@ public class LaskentaResurssinhakuObservable<R> {
         };
     }
 
-    private Action1<Throwable> resurssiException(long startTime, PyynnonTunniste tunniste) {
+    private Consumer<Throwable> resurssiException(long startTime, PyynnonTunniste tunniste) {
         return error -> {
             long l = System.currentTimeMillis();
             long duration = l - startTime;

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/resource/ValintalaskentaKerrallaResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/resource/ValintalaskentaKerrallaResource.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.*;
 import javax.ws.rs.container.AsyncResponse;

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/resource/ValintalaskentaKerrallaService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/resource/ValintalaskentaKerrallaService.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.Response;
@@ -64,7 +64,7 @@ public class ValintalaskentaKerrallaService {
                 (List<HakukohdeViiteDTO> hakukohdeViitteet) -> {
                     Collection<HakukohdeJaOrganisaatio> haunHakukohteetOids = kasitteleHakukohdeViitteet(hakukohdeViitteet, hakuOid, laskentaParams.getMaski(), callback);
 
-                    authCheck.toBlocking().forEach(
+                    authCheck.blockingNext().forEach(
                             authorityCheck -> haunHakukohteetOids
                                     .forEach(hk -> {
                                         if (!authorityCheck.test(hk.getHakukohdeOid())) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/resource/ValintalaskentaExcelResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/resource/ValintalaskentaExcelResource.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintatapajono/resource/ValintatapajonoResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintatapajono/resource/ValintatapajonoResource.java
@@ -1,7 +1,6 @@
 package fi.vm.sade.valinta.kooste.valintatapajono.resource;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static rx.observables.BlockingObservable.from;
 
 import fi.vm.sade.auditlog.User;
 import fi.vm.sade.authentication.business.service.Authorizer;
@@ -160,6 +159,6 @@ public class ValintatapajonoResource {
     }
 
     private String findTarjoajaOid(@QueryParam("hakukohdeOid") String hakukohdeOid) {
-        return HakukohdeHelper.tarjoajaOid(from(tarjontaResource.haeHakukohde(hakukohdeOid).timeout(1, MINUTES)).first());
+        return HakukohdeHelper.tarjoajaOid(tarjontaResource.haeHakukohde(hakukohdeOid).timeout(1, MINUTES).blockingFirst());
     }
 }

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintatapajono/route/impl/ValintatapajonoVientiRouteImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintatapajono/route/impl/ValintatapajonoVientiRouteImpl.java
@@ -103,7 +103,7 @@ public class ValintatapajonoVientiRouteImpl extends AbstractDokumenttiRouteBuild
                             } else {
                                 hakemukset = ataruAsyncResource.getApplicationsByHakukohde(hakukohdeOid)
                                         .timeout(1, TimeUnit.MINUTES)
-                                        .toBlocking().first();
+                                        .blockingFirst();
                             }
                             LOG.debug("Saatiin hakemukset {}", hakemukset.size());
                             dokumenttiprosessi(exchange).inkrementoiTehtyjaToita();

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/OsoiteHaku.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/OsoiteHaku.java
@@ -62,7 +62,7 @@ public class OsoiteHaku {
             if (rdto.getParentOid() != null) {
                 LOG.error("Ei saatu hakijapalveluiden osoitetta talta organisaatiolta. Tutkitaan seuraava {}", Arrays.toString(oids.toArray()));
                 return haeOsoiteHierarkisesti(haeOsoiteKomponentti, organisaatioAsyncResource, kieli, oids, responseToOrganisaatio(organisaatioAsyncResource
-                        .haeOrganisaatio(rdto.getParentOid()).timeout(1, MINUTES).toBlocking().first()), organisaationimi);
+                        .haeOrganisaatio(rdto.getParentOid()).timeout(1, MINUTES).blockingFirst()), organisaationimi);
             } else {
                 LOG.error("Ei saatu hakijapalveluiden osoitetta! Kaytiin lapi organisaatiot {}!", Arrays.toString(oids.toArray()));
                 return null;

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/JalkiohjauskirjeService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/JalkiohjauskirjeService.java
@@ -1,12 +1,9 @@
 package fi.vm.sade.valinta.kooste.viestintapalvelu.route;
 
-import java.io.InputStream;
-import java.util.List;
-
-import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.HyvaksymiskirjeDTO;
 import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.JalkiohjauskirjeDTO;
 import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.KirjeProsessi;
-import rx.Observable;
+
+import java.util.List;
 
 public interface JalkiohjauskirjeService {
     void jalkiohjauskirjeetHakemuksille(KirjeProsessi prosessi, JalkiohjauskirjeDTO jalkiohjauskirjeDTO, List<String> hakemusOids);

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/impl/EPostiServiceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/impl/EPostiServiceImpl.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/impl/KirjeetHakukohdeCache.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/impl/KirjeetHakukohdeCache.java
@@ -20,7 +20,6 @@ import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.MetaHakukohde;
 import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.Teksti;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static rx.observables.BlockingObservable.from;
 
 @Component
 public class KirjeetHakukohdeCache {
@@ -35,7 +34,7 @@ public class KirjeetHakukohdeCache {
         return metaHakukohdeCache.get(hakukohdeOid,
                 () -> {
                     //TODO Tee tästä aidosti asynkroninen!
-                    HakukohdeV1RDTO hakukohde = from(hakuV1AsyncResource.haeHakukohde(hakukohdeOid).timeout(30, SECONDS)).first();
+                    HakukohdeV1RDTO hakukohde = hakuV1AsyncResource.haeHakukohde(hakukohdeOid).timeout(30, SECONDS).blockingFirst();
                     Teksti hakukohdeNimi = new Teksti(hakukohde.getHakukohteenNimet());
                     String opetuskieli = getOpetuskieli(hakukohde.getOpetusKielet());
                     LOG.debug("Hakukohdekieli({}) Oid({}) Opetuskieli({})", hakukohdeNimi.getKieli(), hakukohdeOid, opetuskieli);

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/service/OsoitetarratService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/service/OsoitetarratService.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/test/java/fi/vm/sade/valinta/kooste/erillishaku/excel/ErillishaunTuontiServiceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/erillishaku/excel/ErillishaunTuontiServiceTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static rx.Observable.just;
+import static io.reactivex.Observable.just;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 
@@ -52,8 +52,8 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
-import rx.Observable;
-import rx.schedulers.Schedulers;
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
 
 import java.io.InputStream;
 import java.time.LocalDate;
@@ -265,7 +265,7 @@ public class ErillishaunTuontiServiceTest {
                     failingOppijanumerorekisteriResource,
                     valintaTulosServiceAsyncResource,
                     koodistoCachedAsyncResource,
-                    Schedulers.immediate()
+                    Schedulers.trampoline()
             );
             assertEquals(0, applicationAsyncResource.results.size());
             tuontiService.tuoExcelistä(new AuditSession(PERSON_2_OID, emptyList(), "", ""), prosessi, erillisHaku, kkHakuToisenAsteenValintatuloksella());
@@ -287,7 +287,7 @@ public class ErillishaunTuontiServiceTest {
                     henkiloAsyncResource,
                     failingValintaTuloseServiceAsyncResource,
                     koodistoCachedAsyncResource,
-                    Schedulers.immediate()
+                    Schedulers.trampoline()
             );
             tuontiService.tuoExcelistä(new AuditSession(PERSON_2_OID, emptyList(), "", ""),prosessi, erillisHaku, kkHakuToisenAsteenValintatuloksella());
             Mockito.verify(prosessi).keskeyta(Matchers.<Collection<Poikkeus>>any());
@@ -302,7 +302,7 @@ public class ErillishaunTuontiServiceTest {
                     henkiloAsyncResource,
                     valintaTulosServiceAsyncResource,
                     koodistoCachedAsyncResource,
-                    Schedulers.immediate()
+                    Schedulers.trampoline()
             );
             assertNull(henkiloAsyncResource.henkiloPrototyypit);
             KirjeProsessi prosessi = new ErillishakuProsessiDTO(1);
@@ -406,7 +406,7 @@ class ErillisHakuTuontiTestCase {
                 henkiloAsyncResource,
                 valintaTulosServiceAsyncResource,
                 koodistoCachedAsyncResource,
-                Schedulers.immediate()
+                Schedulers.trampoline()
         );
         tuontiService.tuoExcelistä(new AuditSession(PERSON_1_OID, new ArrayList<>(), "", ""), prosessi, erillisHaku, data);
         Mockito.verify(prosessi).valmistui("ok");
@@ -418,7 +418,7 @@ class ErillisHakuTuontiTestCase {
                 mockHenkiloAsyncResource,
                 valintaTulosServiceAsyncResource,
                 koodistoCachedAsyncResource,
-                Schedulers.immediate()
+                Schedulers.trampoline()
         );
         tuontiService.tuoJson(new AuditSession(PERSON_1_OID, new ArrayList<>(), "", ""), prosessi, erillisHaku, rivit, false);
         Mockito.verify(prosessi).valmistui("ok");

--- a/src/test/java/fi/vm/sade/valinta/kooste/erillishaku/excel/ErillishaunVientiServiceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/erillishaku/excel/ErillishaunVientiServiceTest.java
@@ -13,7 +13,7 @@ import fi.vm.sade.valinta.kooste.erillishaku.service.impl.ErillishaunVientiServi
 import fi.vm.sade.valinta.kooste.external.resource.hakuapp.ApplicationAsyncResource;
 import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.KirjeProsessi;
 import org.mockito.Mockito;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import org.junit.Test;
 
@@ -47,6 +47,8 @@ public class ErillishaunVientiServiceTest {
 
     @Test
     public void suoritaEpaonnistunutVientiTest() {
+        when(mockTilaAsyncResource.getErillishaunValinnantulokset(anyObject(), anyString())).thenReturn(Observable.just(Lists.newArrayList()));
+        when(mockTilaAsyncResource.fetchLukuvuosimaksut(anyString(),any())).thenReturn(Observable.just(Lists.newArrayList()));
         final ErillishakuDTO erillishaku = new ErillishakuDTO(Hakutyyppi.KORKEAKOULU, "1", "1", "1", "1");
         final KirjeProsessi prosessi = mock(KirjeProsessi.class);
         final ApplicationAsyncResource failingResource = mock(ApplicationAsyncResource.class);

--- a/src/test/java/fi/vm/sade/valinta/kooste/external/resource/ataru/impl/AtaruAsyncResourceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/external/resource/ataru/impl/AtaruAsyncResourceTest.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import org.springframework.test.util.ReflectionTestUtils;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import java.util.Collections;
@@ -87,7 +87,7 @@ public class AtaruAsyncResourceTest {
         when(mockOnr.haeHenkilot(Collections.singletonList("1.2.246.562.24.86368188549"))).thenReturn(Observable.just(Collections.singletonList(onrHenkilo)));
 
         List<HakemusWrapper> applications = ataruAsyncResource.getApplicationsByOids(Lists.newArrayList(hakemusOid1, hakemusOid2, hakemusOid3))
-                .timeout(1, SECONDS).toBlocking().first();
+                .timeout(1, SECONDS).blockingFirst();
         assertEquals(3, applications.size());
         assertEquals("FIN", applications.get(0).getAsuinmaa());
         assertEquals("MAF", applications.get(1).getAsuinmaa());

--- a/src/test/java/fi/vm/sade/valinta/kooste/external/resource/hakuapp/impl/ApplicationAsyncResourceImplTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/external/resource/hakuapp/impl/ApplicationAsyncResourceImplTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.test.util.ReflectionTestUtils;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import java.util.Arrays;
@@ -75,7 +75,7 @@ public class ApplicationAsyncResourceImplTest {
                 Mockito.verifyNoMoreInteractions(webClient);
                 return Observable.just(Arrays.asList(hakemus1, hakemus2));
             });
-        List<HakemusWrapper> applications = applicationAsyncResource.getApplicationsByHakemusOids(Arrays.asList("hakemus1Oid", "hakemus2Oid")).timeout(1, SECONDS).toBlocking().first();
+        List<HakemusWrapper> applications = applicationAsyncResource.getApplicationsByHakemusOids(Arrays.asList("hakemus1Oid", "hakemus2Oid")).timeout(1, SECONDS).blockingFirst();
 
         assertTrue(EqualsBuilder.reflectionEquals(new HakuappHakemusWrapper(hakemus1), applications.stream().filter(h -> h.getOid().equals("hakemus1")).findFirst().get()));
         assertTrue(EqualsBuilder.reflectionEquals(new HakuappHakemusWrapper(hakemus2), applications.stream().filter(h -> h.getOid().equals("hakemus2")).findFirst().get()));
@@ -98,7 +98,7 @@ public class ApplicationAsyncResourceImplTest {
                 return Observable.just(Arrays.asList(hakemus1, hakemus2, hakemus3));
             });
         List<HakemusWrapper> applications = applicationAsyncResource.getApplicationsByHakemusOids(
-                Arrays.asList("hakemus1Oid", "hakemus2Oid", "hakemus3Oid")).timeout(1, SECONDS).toBlocking().first();
+                Arrays.asList("hakemus1Oid", "hakemus2Oid", "hakemus3Oid")).timeout(1, SECONDS).blockingFirst();
 
         assertEquals(2, applications.size());
         assertTrue(EqualsBuilder.reflectionEquals(new HakuappHakemusWrapper(hakemus1), applications.stream().filter(h -> h.getOid().equals("hakemus1")).findFirst().get()));
@@ -126,7 +126,7 @@ public class ApplicationAsyncResourceImplTest {
             });
         List<HakemusWrapper> applications = applicationAsyncResource.getApplicationsByhakemusOidsInParts("hakuOid",
                 Arrays.asList("hakemus1Oid", "hakemus2Oid"),
-                Collections.singletonList("hakemusOid")).timeout(1, SECONDS).toBlocking().first();
+                Collections.singletonList("hakemusOid")).timeout(1, SECONDS).blockingFirst();
 
         assertTrue(EqualsBuilder.reflectionEquals(new HakuappHakemusWrapper(hakemus1), applications.stream().filter(h -> h.getOid().equals("hakemus1")).findFirst().get()));
         assertTrue(EqualsBuilder.reflectionEquals(new HakuappHakemusWrapper(hakemus2), applications.stream().filter(h -> h.getOid().equals("hakemus2")).findFirst().get()));
@@ -152,7 +152,7 @@ public class ApplicationAsyncResourceImplTest {
                 Mockito.verifyNoMoreInteractions(webClient);
                 return Observable.just(Arrays.asList(hakemus1, hakemus2));
             });
-        List<HakemusWrapper> applications = applicationAsyncResource.getApplicationsByOid(hakuOid, hakukohdeOid).timeout(1, SECONDS).toBlocking().first();
+        List<HakemusWrapper> applications = applicationAsyncResource.getApplicationsByOid(hakuOid, hakukohdeOid).timeout(1, SECONDS).blockingFirst();
 
         assertTrue(EqualsBuilder.reflectionEquals(new HakuappHakemusWrapper(hakemus1), applications.stream().filter(h -> h.getOid().equals("hakemus1")).findFirst().get()));
         assertTrue(EqualsBuilder.reflectionEquals(new HakuappHakemusWrapper(hakemus2), applications.stream().filter(h -> h.getOid().equals("hakemus2")).findFirst().get()));

--- a/src/test/java/fi/vm/sade/valinta/kooste/external/resource/tarjonta/impl/TarjontaAsyncResourceImplTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/external/resource/tarjonta/impl/TarjontaAsyncResourceImplTest.java
@@ -7,7 +7,7 @@ import com.google.common.reflect.TypeToken;
 
 import fi.vm.sade.valinta.kooste.external.resource.tarjonta.dto.ResultSearch;
 import org.junit.Test;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 import java.util.Map;
@@ -20,7 +20,7 @@ public class TarjontaAsyncResourceImplTest {
 
         Observable<ResultSearch> a = Observable.just(TarjontaAsyncResourceImplHelper.getGson().fromJson(json, new TypeToken<ResultSearch>() {}.getType()));
         Observable<Map<String, List<String>>> observable = TarjontaAsyncResourceImplHelper.resultSearchToHakukohdeRyhmaMap(a);
-        Map<String, List<String>> res = observable.timeout(10, SECONDS).toBlocking().single();
+        Map<String, List<String>> res = observable.timeout(10, SECONDS).blockingSingle();
         assertEquals(2, res.size());
         assertEquals(3, res.get("oid1").size());
         assertTrue(res.get("oid1").contains("ryhmaoid1"));
@@ -32,7 +32,7 @@ public class TarjontaAsyncResourceImplTest {
 
         Observable<ResultSearch> a = Observable.just(TarjontaAsyncResourceImplHelper.getGson().fromJson(json, new TypeToken<ResultSearch>() {}.getType()));
         Observable<Map<String, List<String>>> observable = TarjontaAsyncResourceImplHelper.resultSearchToHakukohdeRyhmaMap(a);
-        Map<String, List<String>> res = observable.timeout(10, SECONDS).toBlocking().single();
+        Map<String, List<String>> res = observable.timeout(10, SECONDS).blockingSingle();
         assertEquals(2, res.size());
         assertEquals(0, res.get("oid1").size());
         assertEquals(0, res.get("oid2").size());
@@ -44,7 +44,7 @@ public class TarjontaAsyncResourceImplTest {
 
         Observable<ResultSearch> a = Observable.just(TarjontaAsyncResourceImplHelper.getGson().fromJson(json, new TypeToken<ResultSearch>() {}.getType()));
         Observable<Map<String, List<String>>> observable = TarjontaAsyncResourceImplHelper.resultSearchToHakukohdeRyhmaMap(a);
-        Map<String, List<String>> res = observable.timeout(10, SECONDS).toBlocking().single();
+        Map<String, List<String>> res = observable.timeout(10, SECONDS).blockingSingle();
         assertEquals(0, res.size());
     }
 

--- a/src/test/java/fi/vm/sade/valinta/kooste/hyvaksymiskirjeet/HakijatoimistoTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/hyvaksymiskirjeet/HakijatoimistoTest.java
@@ -14,7 +14,7 @@ import fi.vm.sade.valinta.kooste.viestintapalvelu.komponentti.ViestintapalveluOb
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.*;
 import java.util.concurrent.Semaphore;

--- a/src/test/java/fi/vm/sade/valinta/kooste/kela/KelaRouteTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/kela/KelaRouteTest.java
@@ -34,7 +34,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/fi/vm/sade/valinta/kooste/koekutsukirjeet/KoekutsukirjeetTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/koekutsukirjeet/KoekutsukirjeetTest.java
@@ -17,7 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;

--- a/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaFailTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaFailTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import fi.vm.sade.valinta.kooste.mocks.MockOrganisaationAsyncResource;
 import fi.vm.sade.valinta.kooste.valintalaskenta.resource.ValintalaskentaKerrallaResource;
 import fi.vm.sade.valinta.seuranta.dto.LaskentaTyyppi;
+import io.reactivex.internal.operators.observable.ObservableJust;
 import org.apache.cxf.jaxrs.impl.ResponseImpl;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -27,7 +28,7 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.container.AsyncResponse;
 import java.util.ArrayList;
@@ -57,7 +58,7 @@ public class LaskentaKerrallaFailTest {
             if (seurantaCount.getAndIncrement() < 1)
                 return Observable.just(LASKENTASEURANTA_ID);
             else {
-                return Observable.just(null);
+                return new ObservableJust<>(null);
             }
         }).when(Mocks.laskentaSeurantaAsyncResource).otaSeuraavaLaskentaTyonAlle();
     }

--- a/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaFailTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaFailTest.java
@@ -32,6 +32,7 @@ import io.reactivex.Observable;
 
 import javax.ws.rs.container.AsyncResponse;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -58,7 +59,7 @@ public class LaskentaKerrallaFailTest {
             if (seurantaCount.getAndIncrement() < 1)
                 return Observable.just(LASKENTASEURANTA_ID);
             else {
-                return new ObservableJust<>(null);
+                return Observable.just(Optional.empty());
             }
         }).when(Mocks.laskentaSeurantaAsyncResource).otaSeuraavaLaskentaTyonAlle();
     }

--- a/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaTest.java
@@ -19,6 +19,7 @@ import fi.vm.sade.valinta.seuranta.dto.LaskentaDto;
 import fi.vm.sade.valinta.seuranta.dto.LaskentaTila;
 import fi.vm.sade.valinta.seuranta.dto.LaskentaTyyppi;
 import fi.vm.sade.valintalaskenta.domain.dto.LaskeDTO;
+import io.reactivex.internal.operators.observable.ObservableJust;
 import org.apache.cxf.jaxrs.impl.ResponseImpl;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -33,7 +34,7 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.container.AsyncResponse;
 import java.util.ArrayList;
@@ -87,7 +88,7 @@ public class LaskentaKerrallaTest {
                 VALINTARYHMA_OID,
                 LaskentaTyyppi.HAKUKOHDE,
                 false,
-                new ArrayList(),
+                new ArrayList<>(),
                 asyncResponse);
         synchronized (signal) {
             signal.wait(10000);
@@ -122,13 +123,13 @@ public class LaskentaKerrallaTest {
         when(Mocks.valintaperusteetAsyncResource.haeValintaperusteet(any(), any()))
                 .thenAnswer(
                         invocation -> Observable
-                            .from(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.valintaperusteet(HAKU_OID, TARJOAJA_OID, HAKUKOHDE_OID))))
+                            .fromIterable(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.valintaperusteet(HAKU_OID, TARJOAJA_OID, HAKUKOHDE_OID))))
                 );
 
         when(Mocks.valintaperusteetAsyncResource.haeHakijaryhmat(any()))
                 .thenAnswer(
                         invocation -> Observable
-                                .from(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.valintaperusteet(HAKU_OID, TARJOAJA_OID, HAKUKOHDE_OID)))
+                                .fromIterable(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.valintaperusteet(HAKU_OID, TARJOAJA_OID, HAKUKOHDE_OID)))
                                 ));
 
         when(Mocks.ohjausparametritAsyncResource.haeHaunOhjausparametrit(any())).thenReturn(Observable.just(LaskentaKerrallaTestData.ohjausparametrit()));
@@ -136,22 +137,22 @@ public class LaskentaKerrallaTest {
         when(Mocks.applicationAsyncResource.getApplicationsByOid(eq(HAKU_OID), eq(HAKUKOHDE_OID)))
                 .thenAnswer(
                         invocation -> Observable
-                                .from(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.hakemus(HAKEMUS_OID, PERSON_OID)))
+                                .fromIterable(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.hakemus(HAKEMUS_OID, PERSON_OID)))
                                 ));
 
         when(Mocks.suoritusrekisteriAsyncResource.getOppijatByHakukohde(eq(HAKUKOHDE_OID), any()))
                 .thenAnswer(
                         invocation ->
                             Observable
-                                    .from(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.oppija()))
+                                    .fromIterable(Arrays.asList(Arrays.asList(LaskentaKerrallaTestData.oppija()))
                 ));
         when(Mocks.valintalaskentaAsyncResource.laske(any()))
                 .thenAnswer(
                         invocation -> Observable
-                                .from(Arrays.asList("string"))
+                                .fromIterable(Arrays.asList("string"))
                 );
         when(Mocks.tarjontaAsyncResource.haeHaku(any()))
-                .thenAnswer(invocation -> rx.Observable.just(buildHakuDto()));
+                .thenAnswer(invocation -> Observable.just(buildHakuDto()));
         when(Mocks.laskentaSeurantaAsyncResource.laskenta(LASKENTASEURANTA_ID)).thenReturn(Observable.just(
             (new LaskentaDto(LASKENTASEURANTA_ID, "","","", HAKU_OID, System.currentTimeMillis(), LaskentaTila.MENEILLAAN, LaskentaTyyppi.HAKUKOHDE, null, Lists.newArrayList(new HakukohdeDto(HAKUKOHDE_OID, "org_oid")), false, 0, false, null, true))));
 
@@ -160,7 +161,7 @@ public class LaskentaKerrallaTest {
             if (seurantaCount.getAndIncrement() < 1) {
                 return Observable.just(LASKENTASEURANTA_ID);
             } else {
-                return Observable.just(null);
+                return new ObservableJust<>(null);
             }
         }).when(Mocks.laskentaSeurantaAsyncResource).otaSeuraavaLaskentaTyonAlle();
     }

--- a/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/laskentakerralla/LaskentaKerrallaTest.java
@@ -161,7 +161,7 @@ public class LaskentaKerrallaTest {
             if (seurantaCount.getAndIncrement() < 1) {
                 return Observable.just(LASKENTASEURANTA_ID);
             } else {
-                return new ObservableJust<>(null);
+                return Observable.just(Optional.empty());
             }
         }).when(Mocks.laskentaSeurantaAsyncResource).otaSeuraavaLaskentaTyonAlle();
     }

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockApplicationAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockApplicationAsyncResource.java
@@ -6,7 +6,7 @@ import fi.vm.sade.valinta.kooste.external.resource.hakuapp.dto.*;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
 import fi.vm.sade.valinta.kooste.util.HakuappHakemusWrapper;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.*;
@@ -96,7 +96,7 @@ public class MockApplicationAsyncResource implements ApplicationAsyncResource {
 
     @Override
     public Observable<List<HakemusWrapper>> putApplicationPrototypes(final String hakuOid, final String hakukohdeOid, final String tarjoajaOid, final Collection<HakemusPrototyyppi> hakemusPrototyypit) {
-        return Observable.from(Optional.ofNullable(MockApplicationAsyncResource.<List<HakemusWrapper>>serviceAvailableCheck()).orElseGet(
+        return Observable.fromFuture(Optional.ofNullable(MockApplicationAsyncResource.<List<HakemusWrapper>>serviceAvailableCheck()).orElseGet(
                 () -> {
                     results.add(new Result(hakuOid, hakukohdeOid, tarjoajaOid, hakemusPrototyypit));
                     return Futures.immediateFuture(hakemusPrototyypit.stream()
@@ -119,7 +119,7 @@ public class MockApplicationAsyncResource implements ApplicationAsyncResource {
 
     @Override
     public Observable<List<HakemusWrapper>> getApplicationsByOids(String hakuOid, Collection<String> hakukohdeOids) {
-        return Observable.from(Optional.ofNullable(MockApplicationAsyncResource.<List<HakemusWrapper>>serviceAvailableCheck()).orElseGet(() -> {
+        return Observable.fromFuture(Optional.ofNullable(MockApplicationAsyncResource.<List<HakemusWrapper>>serviceAvailableCheck()).orElseGet(() -> {
             if (resultReference.get() != null) {
                 return Futures.immediateFuture(resultReference.get());
             } else {
@@ -131,7 +131,7 @@ public class MockApplicationAsyncResource implements ApplicationAsyncResource {
 
     @Override
     public Observable<List<HakemusWrapper>> getApplicationsByOidsWithPOST(String hakuOid, Collection<String> hakukohdeOids) {
-        return Observable.from(Optional.ofNullable(MockApplicationAsyncResource.<List<HakemusWrapper>>serviceAvailableCheck()).orElseGet(() -> {
+        return Observable.fromFuture(Optional.ofNullable(MockApplicationAsyncResource.<List<HakemusWrapper>>serviceAvailableCheck()).orElseGet(() -> {
             if (resultReference.get() != null) {
                 return Futures.immediateFuture(resultReference.get());
             } else {

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockAtaruAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockAtaruAsyncResource.java
@@ -3,18 +3,18 @@ package fi.vm.sade.valinta.kooste.mocks;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+
 import fi.vm.sade.valinta.kooste.external.resource.ataru.AtaruAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.ataru.dto.AtaruHakemus;
 import fi.vm.sade.valinta.kooste.external.resource.oppijanumerorekisteri.dto.HenkiloPerustietoDto;
 import fi.vm.sade.valinta.kooste.util.AtaruHakemusWrapper;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
+import io.reactivex.Observable;
 import org.apache.commons.io.IOUtils;
 import org.mockito.internal.util.collections.Sets;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
-import rx.Observable;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockAuthorityCheckService.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockAuthorityCheckService.java
@@ -4,7 +4,7 @@ import fi.vm.sade.valinta.kooste.pistesyotto.service.HakukohdeOIDAuthorityCheck;
 import fi.vm.sade.valinta.kooste.security.AuthorityCheckService;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.ForbiddenException;
 import java.util.Collection;

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockDokumentinSeurantaAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockDokumentinSeurantaAsyncResource.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import fi.vm.sade.valinta.kooste.external.resource.seuranta.DokumentinSeurantaAsyncResource;
 import fi.vm.sade.valinta.seuranta.dto.DokumenttiDto;
 import fi.vm.sade.valinta.seuranta.dto.VirheilmoitusDto;
-import rx.Observable;
+import io.reactivex.Observable;
 
 /**
  * @author Jussi Jartamo

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockOhjausparametritAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockOhjausparametritAsyncResource.java
@@ -3,7 +3,7 @@ package fi.vm.sade.valinta.kooste.mocks;
 import fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.OhjausparametritAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.ohjausparametrit.dto.ParametritDTO;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 @Service
 public class MockOhjausparametritAsyncResource implements OhjausparametritAsyncResource {

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockOppijanumerorekisteriAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockOppijanumerorekisteriAsyncResource.java
@@ -9,7 +9,7 @@ import fi.vm.sade.valinta.kooste.external.resource.oppijanumerorekisteri.dto.Hen
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -48,7 +48,7 @@ public class MockOppijanumerorekisteriAsyncResource implements Oppijanumerorekis
     }
     @Override
     public Observable<List<HenkiloPerustietoDto>> haeTaiLuoHenkilot(final List<HenkiloCreateDTO> hp) {
-        return Observable.from(Optional.ofNullable(MockOppijanumerorekisteriAsyncResource.<List<HenkiloPerustietoDto>>serviceAvailableCheck()).orElseGet(
+        return Observable.fromFuture(Optional.ofNullable(MockOppijanumerorekisteriAsyncResource.<List<HenkiloPerustietoDto>>serviceAvailableCheck()).orElseGet(
                 () -> futureSupplier.apply(hp)));
     }
     @Override

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockOrganisaationAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockOrganisaationAsyncResource.java
@@ -4,7 +4,7 @@ import fi.vm.sade.organisaatio.resource.dto.HakutoimistoDTO;
 import fi.vm.sade.valinta.kooste.external.resource.organisaatio.OrganisaatioAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.organisaatio.dto.OrganisaatioTyyppiHierarkia;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import javax.ws.rs.core.Response;

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockSuoritusrekisteriAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockSuoritusrekisteriAsyncResource.java
@@ -7,7 +7,7 @@ import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.dto.Arvosan
 import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.dto.Oppija;
 import fi.vm.sade.valinta.kooste.external.resource.suoritusrekisteri.dto.Suoritus;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -131,24 +131,24 @@ public class MockSuoritusrekisteriAsyncResource implements SuoritusrekisteriAsyn
     }
 
     @Override
-    public Observable<Void> deleteSuoritus(String suoritusId) {
+    public Observable<String> deleteSuoritus(String suoritusId) {
         deletedSuorituksetRef.getAndUpdate((List<String> suoritusIdt) -> {
             suoritusIdt.add(suoritusId);
             return suoritusIdt;
         });
         Suoritus suoritus = new Suoritus();
         suoritus.setId(suoritusId);
-        return Observable.just(null);
+        return Observable.just("OK");
     }
 
     @Override
-    public Observable<Void> deleteArvosana(String arvosanaId) {
+    public Observable<String> deleteArvosana(String arvosanaId) {
         deletedArvosanatRef.getAndUpdate((List<String> arvosanaIdt) -> {
             arvosanaIdt.add(arvosanaId);
             return arvosanaIdt;
         });
         Arvosana arvosana = new Arvosana();
         arvosana.setId(arvosanaId);
-        return Observable.just(null);
+        return Observable.just("OK");
     }
 }

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockTarjontaAsyncService.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockTarjontaAsyncService.java
@@ -9,7 +9,7 @@ import fi.vm.sade.tarjonta.service.resources.v1.dto.HakukohdeV1RDTO;
 import fi.vm.sade.valinta.kooste.external.resource.tarjonta.TarjontaAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.tarjonta.dto.ResultOrganization;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintaTulosServiceAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintaTulosServiceAsyncResource.java
@@ -18,7 +18,7 @@ import fi.vm.sade.valinta.kooste.external.resource.valintatulosservice.dto.Valin
 import fi.vm.sade.valinta.kooste.proxy.resource.valintatulosservice.TilaHakijalleDto;
 import fi.vm.sade.valinta.kooste.proxy.resource.valintatulosservice.VastaanottoAikarajaMennytDTO;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.HashMap;
 import java.util.List;
@@ -53,7 +53,7 @@ public class MockValintaTulosServiceAsyncResource implements ValintaTulosService
     }
 
     @Override
-    public Observable<Void> saveLukuvuosimaksut(String hakukohdeOid, AuditSession session, List<LukuvuosimaksuMuutos> muutokset) {
+    public Observable<String> saveLukuvuosimaksut(String hakukohdeOid, AuditSession session, List<LukuvuosimaksuMuutos> muutokset) {
         return Observable.empty();
     }
 

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintalaskentaAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintalaskentaAsyncResource.java
@@ -6,7 +6,7 @@ import fi.vm.sade.valintalaskenta.domain.dto.LaskeDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.ValinnanvaiheDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.ValintatietoValinnanvaiheDTO;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintalaskentaValintakoeAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintalaskentaValintakoeAsyncResource.java
@@ -4,7 +4,7 @@ import fi.vm.sade.valinta.kooste.external.resource.valintalaskenta.Valintalasken
 import fi.vm.sade.valintalaskenta.domain.dto.valintakoe.ValintakoeOsallistuminenDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.HakemusOsallistuminenDTO;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintaperusteetAsyncResource.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/mocks/MockValintaperusteetAsyncResource.java
@@ -3,7 +3,7 @@ package fi.vm.sade.valinta.kooste.mocks;
 import fi.vm.sade.service.valintaperusteet.dto.*;
 import fi.vm.sade.valinta.kooste.external.resource.valintaperusteet.ValintaperusteetAsyncResource;
 import org.springframework.stereotype.Service;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.Collection;

--- a/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoE2ETest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoE2ETest.java
@@ -207,7 +207,7 @@ public class PistesyottoE2ETest extends PistesyotonTuontiTestBase {
                 .query("hakukohdeOid", hakukohdeOidFromUiRequest)
                 .header("Content-Type", "application/octet-stream")
                 .accept(MediaType.APPLICATION_JSON)
-                .post(new ClassPathResource("pistesyotto/pistesyotto.xlsx").getInputStream());
+                .post(IOUtils.toByteArray(new ClassPathResource("pistesyotto/pistesyotto.xlsx").getInputStream()));
         Assert.assertEquals("", r.readEntity(String.class));
         Assert.assertEquals(204, r.getStatus());
         try {

--- a/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoResourceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoResourceTest.java
@@ -45,7 +45,7 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;

--- a/src/test/java/fi/vm/sade/valinta/kooste/proxy/resource/suoritukset/OppijanSuorituksetProxyResourceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/proxy/resource/suoritukset/OppijanSuorituksetProxyResourceTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/src/test/java/fi/vm/sade/valinta/kooste/security/AuthorityCheckServiceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/security/AuthorityCheckServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.GrantedAuthority;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.ForbiddenException;
 import java.util.Collection;

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintakokeet/AktiivistenHakemustenValintakoeResourceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintakokeet/AktiivistenHakemustenValintakoeResourceTest.java
@@ -1,9 +1,20 @@
 package fi.vm.sade.valinta.kooste.valintakokeet;
 
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakuV1RDTO;
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakukohdeV1RDTO;
 import fi.vm.sade.valinta.kooste.external.resource.ataru.AtaruAsyncResource;
-import fi.vm.sade.valinta.kooste.external.resource.ataru.dto.AtaruHakemus;
 import fi.vm.sade.valinta.kooste.external.resource.hakuapp.ApplicationAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.tarjonta.TarjontaAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.valintalaskenta.ValintalaskentaValintakoeAsyncResource;
@@ -12,25 +23,16 @@ import fi.vm.sade.valinta.kooste.spec.tarjonta.TarjontaSpec;
 import fi.vm.sade.valinta.kooste.spec.valintalaskenta.ValintalaskentaSpec.ValintakoeOsallistuminenBuilder;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
 import fi.vm.sade.valintalaskenta.domain.dto.valintakoe.ValintakoeOsallistuminenDTO;
+import io.reactivex.Observable;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
-import rx.Observable;
 
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.OK;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.*;
 
 public class AktiivistenHakemustenValintakoeResourceTest {
     private final String hakukohdeOid = "hakukohdeOid";

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
@@ -144,7 +144,7 @@ public class ValintalaskentaTest {
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, hakukohde2Oid, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, hakukohde3Oid, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaLaskennanTila(uuid, LaskentaTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
-        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(new ObservableJust<>(null));
+        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(Observable.just(Optional.empty()));
 
         LaskentaStartParams laskentaJaHaku = new LaskentaStartParams(auditSession, uuid, hakuOid, false, null, null, hakukohdeJaOrganisaatios, LaskentaTyyppi.HAKUKOHDE);
 
@@ -166,7 +166,7 @@ public class ValintalaskentaTest {
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, ataruHakukohdeOid, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, ataruHakukohdeOid2, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaLaskennanTila(uuid, LaskentaTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
-        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(new ObservableJust<>(null));
+        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(Observable.just(Optional.empty()));
 
         LaskentaStartParams laskentaJaHaku = new LaskentaStartParams(auditSession, uuid, ataruHakuOid, false, null, null, ataruHakukohdeJaOrganisaatios, LaskentaTyyppi.HAKUKOHDE);
 
@@ -202,7 +202,7 @@ public class ValintalaskentaTest {
 
         when(valintalaskentaAsyncResource.laskeJaSijoittele(anyListOf(LaskeDTO.class))).thenReturn(Observable.just("Valintaryhmälaskenta onnistui"));
         when(seurantaAsyncResource.merkkaaLaskennanTila(uuid, LaskentaTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
-        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(new ObservableJust<>(null));
+        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(Observable.just(Optional.empty()));
 
         laskentaActorSystem.suoritaValintalaskentaKerralla(hakuDTO, null, laskentaJaHaku);
         Thread.sleep(500);

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
@@ -1,5 +1,14 @@
 package fi.vm.sade.valinta.kooste.valintalaskenta;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteetDTO;
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakuV1RDTO;
 import fi.vm.sade.valinta.kooste.external.resource.ataru.AtaruAsyncResource;
@@ -24,26 +33,25 @@ import fi.vm.sade.valinta.kooste.valintalaskenta.actor.LaskentaActorSystem;
 import fi.vm.sade.valinta.kooste.valintalaskenta.actor.LaskentaStarter;
 import fi.vm.sade.valinta.kooste.valintalaskenta.actor.dto.HakukohdeJaOrganisaatio;
 import fi.vm.sade.valinta.kooste.valintalaskenta.dto.LaskentaStartParams;
-import fi.vm.sade.valinta.seuranta.dto.*;
+import fi.vm.sade.valinta.seuranta.dto.HakukohdeTila;
+import fi.vm.sade.valinta.seuranta.dto.IlmoitusDto;
+import fi.vm.sade.valinta.seuranta.dto.IlmoitusTyyppi;
+import fi.vm.sade.valinta.seuranta.dto.LaskentaTila;
+import fi.vm.sade.valinta.seuranta.dto.LaskentaTyyppi;
 import fi.vm.sade.valintalaskenta.domain.dto.LaskeDTO;
+import io.reactivex.Observable;
+import io.reactivex.internal.operators.observable.ObservableJust;
 import org.hamcrest.Description;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
-import rx.Observable;
 
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
 
 public class ValintalaskentaTest {
     private static final Hakemus hakemus = new Hakemus();
@@ -136,7 +144,7 @@ public class ValintalaskentaTest {
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, hakukohde2Oid, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, hakukohde3Oid, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaLaskennanTila(uuid, LaskentaTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
-        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(Observable.just(null));
+        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(new ObservableJust<>(null));
 
         LaskentaStartParams laskentaJaHaku = new LaskentaStartParams(auditSession, uuid, hakuOid, false, null, null, hakukohdeJaOrganisaatios, LaskentaTyyppi.HAKUKOHDE);
 
@@ -158,7 +166,7 @@ public class ValintalaskentaTest {
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, ataruHakukohdeOid, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, ataruHakukohdeOid2, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaLaskennanTila(uuid, LaskentaTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
-        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(Observable.just(null));
+        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(new ObservableJust<>(null));
 
         LaskentaStartParams laskentaJaHaku = new LaskentaStartParams(auditSession, uuid, ataruHakuOid, false, null, null, ataruHakukohdeJaOrganisaatios, LaskentaTyyppi.HAKUKOHDE);
 
@@ -194,7 +202,7 @@ public class ValintalaskentaTest {
 
         when(valintalaskentaAsyncResource.laskeJaSijoittele(anyListOf(LaskeDTO.class))).thenReturn(Observable.just("Valintaryhmälaskenta onnistui"));
         when(seurantaAsyncResource.merkkaaLaskennanTila(uuid, LaskentaTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
-        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(Observable.just(null));
+        when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(new ObservableJust<>(null));
 
         laskentaActorSystem.suoritaValintalaskentaKerralla(hakuDTO, null, laskentaJaHaku);
         Thread.sleep(500);

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskentaTulosExcelTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskentaTulosExcelTest.java
@@ -18,13 +18,14 @@ import fi.vm.sade.valinta.kooste.viestintapalvelu.dto.DokumentinLisatiedot;
 import fi.vm.sade.valintalaskenta.domain.dto.OsallistuminenDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintakoe.ValintakoeOsallistuminenDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.HakemusOsallistuminenDTO;
+import io.reactivex.internal.operators.observable.ObservableJust;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
@@ -103,7 +104,7 @@ public class ValintalaskentaTulosExcelTest {
                     Mockito.anyList(),
                     Mockito.anyString(),
                     inputStreamArgumentCaptor.capture()
-            )).thenReturn(Observable.just(null));
+            )).thenReturn(new ObservableJust<Response>(null));
 
 
             DokumentinLisatiedot lisatiedot = new DokumentinLisatiedot();
@@ -213,7 +214,7 @@ public class ValintalaskentaTulosExcelTest {
                     Mockito.anyList(),
                     Mockito.anyString(),
                     inputStreamArgumentCaptor.capture()
-            )).thenReturn(Observable.just(null));
+            )).thenReturn(Observable.just("OK"));
 
 
             DokumentinLisatiedot lisatiedot = new DokumentinLisatiedot();
@@ -340,7 +341,7 @@ public class ValintalaskentaTulosExcelTest {
                     Mockito.anyList(),
                     Mockito.anyString(),
                     inputStreamArgumentCaptor.capture()
-            )).thenReturn(Observable.just(null));
+            )).thenReturn(Observable.just("OK"));
 
 
             DokumentinLisatiedot lisatiedot = new DokumentinLisatiedot();

--- a/src/test/java/fi/vm/sade/valinta/kooste/viestintapalvelu/OsoitetarratServiceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/viestintapalvelu/OsoitetarratServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;


### PR DESCRIPTION
RxJavan päivittäminen 2-versioon muuttaa aika paljon koodia, mutta ei vaikuttanut ongelmallisen PistesyottoE2ETest:n käyttäytymiseen millään tavalla, vaan sen tekemät pisteiden tallentamiset epäonnistuvat timeoutilla edelleen n. puolella ajokerroista.

Niinpä kludgasin testiin uudelleenyritykset.

Jokin tai jotkut RX-streamit eivät emitoi tarvittavia arvoja, jolloin [lopullisen responsen tuottavaa koodia](https://github.com/Opetushallitus/valintalaskentakoostepalvelu/blob/f077d15d5fef34cd5710f0bc553c8d949077091d/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/AbstractPistesyottoKoosteService.java#L244-L258) ei koskaan ajeta. Thread dumpeissa ei näy mitään muuta kuin serverin responsea odottava testikoodi.

Periaatteessa homman tutkimista voi jatkaa [toisessa branchissa olevalla rxjava-debugilla](https://github.com/Opetushallitus/valintalaskentakoostepalvelu/commit/8d0c7d0c0dfde9cefd29c09f99c0eff2023864a1), mutten ainakaan itse tullut sen tulosteesta hullua hurskaammaksi. Streameja starttaa paljon (n. 500 yksittäisen testimetodin ajossa) ja completoituu vähän vähemmän, ja onNextejä tulee huomattavasti vähemmän (n. 50). Valitettavasti rxjava-debugia ei ole RxJavan 2-versiolle.

Ks. myös tämän käyttävä [vastaava päivitys valinta-sharedutils-modulissa](https://github.com/Opetushallitus/valinta-sharedutils/pull/2).