### PR TITLE
Vtku 36 hakukohteittain

### DIFF
--- a/src/main/java/fi/vm/sade/valinta/kooste/util/AtaruHakemusWrapper.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/util/AtaruHakemusWrapper.java
@@ -158,6 +158,9 @@ public class AtaruHakemusWrapper extends HakemusWrapper {
     public boolean getVainSahkoinenViestinta() { return false; }
 
     @Override
+    public boolean getLupaTulosEmail() { return false; }
+
+    @Override
     public boolean hasAsiointikieli() {
         try {
             this.getAsiointikieli();

--- a/src/main/java/fi/vm/sade/valinta/kooste/util/AtaruHakemusWrapper.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/util/AtaruHakemusWrapper.java
@@ -158,7 +158,9 @@ public class AtaruHakemusWrapper extends HakemusWrapper {
     public boolean getVainSahkoinenViestinta() { return false; }
 
     @Override
-    public boolean getLupaTulosEmail() { return false; }
+    public boolean getLupaTulosEmail() {
+        return "Kyllä".equals(StringUtils.trimToEmpty(keyvalues.get("sahkoisen-asioinnin-lupa")));
+    }
 
     @Override
     public boolean hasAsiointikieli() {

--- a/src/main/java/fi/vm/sade/valinta/kooste/util/HakemusWrapper.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/util/HakemusWrapper.java
@@ -81,6 +81,8 @@ public abstract class HakemusWrapper {
 
     public abstract boolean getLupaSahkoiseenAsiointiin();
 
+    public abstract boolean getLupaTulosEmail();
+
     public abstract Collection<String> getHakutoiveOids();
 
     public abstract String getMaksuvelvollisuus(String hakukohdeOid);

--- a/src/main/java/fi/vm/sade/valinta/kooste/util/HakuappHakemusWrapper.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/util/HakuappHakemusWrapper.java
@@ -53,6 +53,7 @@ public class HakuappHakemusWrapper extends HakemusWrapper {
     public final static String TOISEN_ASTEEN_SUORITUS           = "toisen_asteen_suoritus";
     public final static String TOISEN_ASTEEN_SUORITUSMAA        = "toisen_asteen_suoritusmaa";
     public final static String LUPA_SAHKOISEEN_VIESTINTAAN      = "lupatiedot-sahkoinen-viestinta";
+    public final static String LUPA_TULOS_EMAIL                 = "lupaTulosEmail";
     private final static String ULKOMAA_POSTITOIMIPAIKKA        = "kaupunkiUlkomaa";
     private final static String POHJAKOULUTUS                   = "POHJAKOULUTUS";
     private final static String POHJAKOULUTUS_ULKOMAILLA        = "0";
@@ -342,6 +343,16 @@ public class HakuappHakemusWrapper extends HakemusWrapper {
         getLisatiedot(); // lazy load lisatiedot
         if (lisatiedot.containsKey(LUPA_SAHKOISEEN_VIESTINTAAN)) {
             String lupa = lisatiedot.get(LUPA_SAHKOISEEN_VIESTINTAAN);
+            return Boolean.TRUE.equals(Boolean.valueOf(lupa));
+        }
+        return false;
+    }
+
+    @Override
+    public boolean getLupaTulosEmail() {
+        getLisatiedot();
+        if (lisatiedot.containsKey(LUPA_TULOS_EMAIL)) {
+            String lupa = lisatiedot.get(LUPA_TULOS_EMAIL);
             return Boolean.TRUE.equals(Boolean.valueOf(lupa));
         }
         return false;

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/dto/HyvaksymiskirjeDTO.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/dto/HyvaksymiskirjeDTO.java
@@ -10,10 +10,11 @@ public class HyvaksymiskirjeDTO {
     private final Long sijoitteluajoId;
     private final String palautusPvm;
     private final String palautusAika;
+    private final boolean vainTulosEmailinKieltaneet;
 
     public HyvaksymiskirjeDTO(String tarjoajaOid, String sisalto,
                               String templateName, String tag, String hakukohdeOid,
-                              String hakuOid, Long sijoitteluajoId, String palautusPvm, String palautusAika) {
+                              String hakuOid, Long sijoitteluajoId, String palautusPvm, String palautusAika, boolean vainTulosEmailinKieltaneet) {
         this.tarjoajaOid = tarjoajaOid;
         this.sisalto = sisalto;
         this.templateName = templateName;
@@ -23,6 +24,7 @@ public class HyvaksymiskirjeDTO {
         this.sijoitteluajoId = sijoitteluajoId;
         this.palautusAika = palautusAika;
         this.palautusPvm = palautusPvm;
+        this.vainTulosEmailinKieltaneet = vainTulosEmailinKieltaneet;
     }
 
     public String getPalautusAika() {
@@ -60,4 +62,6 @@ public class HyvaksymiskirjeDTO {
     public String getTemplateName() {
         return templateName;
     }
+
+    public boolean getVainTulosEmailinKieltaneet() { return vainTulosEmailinKieltaneet; }
 }

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/resource/ViestintapalveluAktivointiResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/resource/ViestintapalveluAktivointiResource.java
@@ -198,7 +198,9 @@ public class ViestintapalveluAktivointiResource {
             @QueryParam("palautusPvm") String palautusPvm,
             @QueryParam("tag") String tag,
             @QueryParam("hakuOid") String hakuOid,
-            @QueryParam("sijoitteluajoId") Long sijoitteluajoId) {
+            @QueryParam("sijoitteluajoId") Long sijoitteluajoId,
+            @QueryParam("vainTulosEmailinKieltaneet") boolean vainTulosEmailinKieltaneet)
+    {
         try {
             if (templateName == null) {
                 templateName = "jalkiohjauskirje";
@@ -206,11 +208,13 @@ public class ViestintapalveluAktivointiResource {
             if (hakemuksillaRajaus == null) {
                 hakemuksillaRajaus = new DokumentinLisatiedot();
             }
+            LOG.info("Hylkäyskirjeiden luonti aktivoitu hakukohteelle "+ hakukohdeOid + ", vainTulosEmailinKieltaneet: " + vainTulosEmailinKieltaneet);
+
             tag = hakemuksillaRajaus.getTag();
             KoekutsuProsessiImpl prosessi = new KoekutsuProsessiImpl(2);
             dokumenttiProsessiKomponentti.tuoUusiProsessi(prosessi);
             HyvaksymiskirjeDTO hyvaksymiskirjeDTO = new HyvaksymiskirjeDTO(tarjoajaOid, hakemuksillaRajaus.getLetterBodyText(),
-                    templateName, tag, hakukohdeOid, hakuOid, sijoitteluajoId, palautusPvm, palautusAika);
+                    templateName, tag, hakukohdeOid, hakuOid, sijoitteluajoId, palautusPvm, palautusAika, vainTulosEmailinKieltaneet);
             hyvaksymiskirjeetService.jalkiohjauskirjeHakukohteelle(prosessi, hyvaksymiskirjeDTO);
             return prosessi.toProsessiId();
         } catch (Exception e) {
@@ -233,7 +237,8 @@ public class ViestintapalveluAktivointiResource {
             @QueryParam("palautusPvm") String palautusPvm,
             @QueryParam("templateName") String templateName,
             @QueryParam("hakuOid") String hakuOid,
-            @QueryParam("sijoitteluajoId") Long sijoitteluajoId) {
+            @QueryParam("sijoitteluajoId") Long sijoitteluajoId,
+            @QueryParam("vainTulosEmailinKieltaneet") boolean vainTulosEmailinKieltaneet) {
         try {
             if (templateName == null) {
                 templateName = "hyvaksymiskirje";
@@ -241,11 +246,13 @@ public class ViestintapalveluAktivointiResource {
             if (hakemuksillaRajaus == null) {
                 hakemuksillaRajaus = new DokumentinLisatiedot();
             }
+            LOG.info("Hyväksymiskirjeiden luonti aktivoitu hakukohteelle "+ hakukohdeOid + ", vainTulosEmailinKieltaneet: " + vainTulosEmailinKieltaneet);
+
             String tag = hakemuksillaRajaus.getTag();
             KoekutsuProsessiImpl prosessi = new KoekutsuProsessiImpl(2);
             dokumenttiProsessiKomponentti.tuoUusiProsessi(prosessi);
             HyvaksymiskirjeDTO hyvaksymiskirjeDTO = new HyvaksymiskirjeDTO(tarjoajaOid, hakemuksillaRajaus.getLetterBodyText(),
-                    templateName, tag, hakukohdeOid, hakuOid, sijoitteluajoId, palautusPvm, palautusAika);
+                    templateName, tag, hakukohdeOid, hakuOid, sijoitteluajoId, palautusPvm, palautusAika, vainTulosEmailinKieltaneet);
             if (hakemuksillaRajaus.getHakemusOids() == null) {
                 hyvaksymiskirjeetService.hyvaksymiskirjeetHakukohteelle(prosessi, hyvaksymiskirjeDTO);
             } else {

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/resource/ViestintapalveluAktivointiResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/resource/ViestintapalveluAktivointiResource.java
@@ -208,7 +208,6 @@ public class ViestintapalveluAktivointiResource {
             if (hakemuksillaRajaus == null) {
                 hakemuksillaRajaus = new DokumentinLisatiedot();
             }
-            LOG.info("Hylkäyskirjeiden luonti aktivoitu hakukohteelle "+ hakukohdeOid + ", vainTulosEmailinKieltaneet: " + vainTulosEmailinKieltaneet);
 
             tag = hakemuksillaRajaus.getTag();
             KoekutsuProsessiImpl prosessi = new KoekutsuProsessiImpl(2);

--- a/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/impl/HyvaksymiskirjeetServiceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/viestintapalvelu/route/impl/HyvaksymiskirjeetServiceImpl.java
@@ -264,7 +264,9 @@ public class HyvaksymiskirjeetServiceImpl implements HyvaksymiskirjeetService {
                             .filter(h -> !hyvaksymiskirjeDTO.getVainTulosEmailinKieltaneet() || tulosEmailinKieltaneet.contains(h.getHakijaOid()))
                             .collect(Collectors.toList());
                     LOG.info("Filtteröinnin jälkeen jäljellä: " + kohdeHakukohteessaHyvaksytyt.size());
-                    if (kohdeHakukohteessaHyvaksytyt.isEmpty()) {
+                    if (kohdeHakukohteessaHyvaksytyt.isEmpty() && hyvaksymiskirjeDTO.getVainTulosEmailinKieltaneet()) {
+                        throw new RuntimeException(String.format("Yhtään hyväksyttyä ja tulos-emailit kieltänyttä hakemusta ei löytynyt haun %s hakukohteessa %s. Kirjeitä ei voitu muodostaa.", hakuOid, hakukohdeOid));
+                    } else if (kohdeHakukohteessaHyvaksytyt.isEmpty()) {
                         throw new RuntimeException(String.format("Yhtään hyväksyttyä hakemusta ei löytynyt haun %s hakukohteessa %s. Kirjeitä ei voitu muodostaa.", hakuOid, hakukohdeOid));
                     }
 


### PR DESCRIPTION
Lisätty mahdollisuus luoda kirjeet vain sellaisille hyväksytyille hakijoille, joiden hakemukselta EI löydy lupaa sähköiseen asiointiin (ataruhakemukset) tai lupaTulosEmail-lisäkysymystä vastauksella kyllä (haku-app-hakemukset 2019).

Vanha toteutus siis loi kirjeet kaikille hyväksytyille, tässä filtteröidään hyväksyttyjen joukkoa edelleen. 