### PR TITLE
Korjattu pohjakoulutuspäättelyä lukion osalta

### DIFF
--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
@@ -229,8 +229,8 @@ public class HakemuksetConverterUtil {
         if (PohjakoulutusToinenAste.YLIOPPILAS.equals(pohjakoulutusHakemukselta)) {
             boolean suressaValmisJaVahvistettuLukiosuoritus = suorituksetRekisterista.stream().anyMatch(s -> s.isLukio() && s.isVahvistettu() && s.isValmis());
             String hakuVuosi = Integer.toString(haku.getHakukausiVuosi());
-            Optional<AvainArvoDTO> abiturientti = h.getAvaimet().stream().filter(dto -> LK_PAATTOTODISTUSVUOSI.equals(dto.getAvain()) && hakuVuosi.equals(dto.getArvo())).findFirst();
-            if (suressaValmisJaVahvistettuLukiosuoritus || abiturientti.isEmpty()) {
+            boolean isAbiturientti = h.getAvaimet().stream().anyMatch(dto -> LK_PAATTOTODISTUSVUOSI.equals(dto.getAvain()) && hakuVuosi.equals(dto.getArvo()));
+            if (suressaValmisJaVahvistettuLukiosuoritus || !isAbiturientti) {
                 return of(PohjakoulutusToinenAste.YLIOPPILAS);
             } else {
                 LOG.warn("Hakemuksella {} pohjakoulutus lukio, mutta valmista ja vahvistettua lukiosuoritusta ei löydy suoritusrekisteristä. Palautetaan pohjakoulutus PERUSKOULU.", h.getHakemusoid());

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
@@ -38,6 +38,7 @@ import static java.util.stream.Collectors.*;
 public class HakemuksetConverterUtil {
     private static final Logger LOG = LoggerFactory.getLogger(HakemuksetConverterUtil.class);
     public static final String PK_PAATTOTODISTUSVUOSI = "PK_PAATTOTODISTUSVUOSI";
+    public static final String LK_PAATTOTODISTUSVUOSI = "lukioPaattotodistusVuosi";
     public static final String PERUSOPETUS_KIELI = "perusopetuksen_kieli";
     public static final String LUKIO_KIELI = "lukion_kieli";
     public static final String POHJAKOULUTUS = "POHJAKOULUTUS";
@@ -227,7 +228,9 @@ public class HakemuksetConverterUtil {
 
         if (PohjakoulutusToinenAste.YLIOPPILAS.equals(pohjakoulutusHakemukselta)) {
             boolean suressaValmisJaVahvistettuLukiosuoritus = suorituksetRekisterista.stream().anyMatch(s -> s.isLukio() && s.isVahvistettu() && s.isValmis());
-            if (suressaValmisJaVahvistettuLukiosuoritus) {
+            String hakuVuosi = Integer.toString(haku.getHakukausiVuosi());
+            Optional<AvainArvoDTO> abiturientti = h.getAvaimet().stream().filter(dto -> LK_PAATTOTODISTUSVUOSI.equals(dto.getAvain()) && hakuVuosi.equals(dto.getArvo())).findFirst();
+            if (suressaValmisJaVahvistettuLukiosuoritus || abiturientti.isEmpty()) {
                 return of(PohjakoulutusToinenAste.YLIOPPILAS);
             } else {
                 LOG.warn("Hakemuksella {} pohjakoulutus lukio, mutta valmista ja vahvistettua lukiosuoritusta ei löydy suoritusrekisteristä. Palautetaan pohjakoulutus PERUSKOULU.", h.getHakemusoid());

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
@@ -224,8 +224,15 @@ public class HakemuksetConverterUtil {
             suorituksetRekisterista.stream().filter(SuoritusJaArvosanatWrapper::isPerusopetus).allMatch(vahvistettuKeskeytynytPerusopetus)) {
             return of(PohjakoulutusToinenAste.KESKEYTYNYT);
         }
+
         if (PohjakoulutusToinenAste.YLIOPPILAS.equals(pohjakoulutusHakemukselta)) {
-            return of(PohjakoulutusToinenAste.YLIOPPILAS);
+            boolean suressaValmisJaVahvistettuLukiosuoritus = suorituksetRekisterista.stream().anyMatch(s -> s.isLukio() && s.isVahvistettu() && s.isValmis());
+            if (suressaValmisJaVahvistettuLukiosuoritus) {
+                return of(PohjakoulutusToinenAste.YLIOPPILAS);
+            } else {
+                LOG.warn("Hakemuksella {} pohjakoulutus lukio, mutta valmista ja vahvistettua lukiosuoritusta ei löydy suoritusrekisteristä. Palautetaan pohjakoulutus PERUSKOULU.", h.getHakemusoid());
+                return of(PohjakoulutusToinenAste.PERUSKOULU);
+            }
         }
         Optional<SuoritusJaArvosanatWrapper> perusopetus = suorituksetRekisterista.stream()
                 .filter(s -> s.isPerusopetus() && s.isVahvistettu() && !s.isKeskeytynyt())

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/HakemuksetConverterUtilTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/HakemuksetConverterUtilTest.java
@@ -351,11 +351,38 @@ public class HakemuksetConverterUtilTest {
         h.setHakijaOid("1.2.3.4.5.6");
         h.setAvaimet(new ArrayList<AvainArvoDTO>() {{
             this.add(new AvainArvoDTO("POHJAKOULUTUS", PohjakoulutusToinenAste.YLIOPPILAS));
+            this.add(new AvainArvoDTO("lukioPaattotodistusVuosi", "2015"));
         }});
         List<SuoritusJaArvosanat> suoritukset = new ArrayList<SuoritusJaArvosanat>() {{
             add(vahvistamatonLukioKeskeytynytHakukaudella);
         }};
         Assert.assertEquals(PohjakoulutusToinenAste.PERUSKOULU, HakemuksetConverterUtil.pohjakoulutus(haku, h, suoritukset).get());
+    }
+
+    @Test
+    public void pohjakoulutusPeruskouluJosHakemuksellaLukioJaAbiturienttiJaSuressaEiValmistaSuoritusta() {
+        HakemusDTO h = new HakemusDTO();
+        h.setHakijaOid("1.2.3.4.5.6");
+        h.setAvaimet(new ArrayList<AvainArvoDTO>() {{
+            this.add(new AvainArvoDTO("POHJAKOULUTUS", PohjakoulutusToinenAste.YLIOPPILAS));
+            this.add(new AvainArvoDTO("lukioPaattotodistusVuosi", "2015"));
+        }});
+        List<SuoritusJaArvosanat> suoritukset = new ArrayList<SuoritusJaArvosanat>();
+
+        Assert.assertEquals(PohjakoulutusToinenAste.PERUSKOULU, HakemuksetConverterUtil.pohjakoulutus(haku, h, suoritukset).get());
+    }
+
+    @Test
+    public void pohjakoulutusLukioJosHakemuksellaLukioJaEIAbiturienttiJaSuressaEiValmistaSuoritusta() {
+        HakemusDTO h = new HakemusDTO();
+        h.setHakijaOid("1.2.3.4.5.6");
+        h.setAvaimet(new ArrayList<AvainArvoDTO>() {{
+            this.add(new AvainArvoDTO("POHJAKOULUTUS", PohjakoulutusToinenAste.YLIOPPILAS));
+            this.add(new AvainArvoDTO("lukioPaattotodistusVuosi", "2014"));
+        }});
+        List<SuoritusJaArvosanat> suoritukset = new ArrayList<SuoritusJaArvosanat>();
+
+        Assert.assertEquals(PohjakoulutusToinenAste.YLIOPPILAS, HakemuksetConverterUtil.pohjakoulutus(haku, h, suoritukset).get());
     }
 
     @Test

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/HakemuksetConverterUtilTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/HakemuksetConverterUtilTest.java
@@ -75,6 +75,11 @@ public class HakemuksetConverterUtilTest {
                     .setYksilollistaminen("Ei")
                     .setValmistuminen(HAKUKAUDELLA).setValmis()
                     .done();
+    private static final SuoritusJaArvosanat vahvistettuLukioValmisHakukaudella =
+            new SuoritusrekisteriSpec.SuoritusBuilder()
+                    .setLukio().setVahvistettu(true)
+                    .setValmistuminen(HAKUKAUDELLA).setValmis()
+                    .done();
     private static final SuoritusJaArvosanat vahvistamatonPerusopetusValmisHakukaudella =
             new SuoritusrekisteriSpec.SuoritusBuilder()
                     .setPerusopetus().setVahvistettu(false)
@@ -341,7 +346,7 @@ public class HakemuksetConverterUtilTest {
     }
 
     @Test
-    public void pohjakoulutusHakemukseltaJosLukioSuoritusKeskeytynytHakukaudella() {
+    public void pohjakoulutusPeruskouluJosHakemuksellaLukioJaLukioSuoritusKeskeytynytHakukaudella() {
         HakemusDTO h = new HakemusDTO();
         h.setHakijaOid("1.2.3.4.5.6");
         h.setAvaimet(new ArrayList<AvainArvoDTO>() {{
@@ -350,7 +355,7 @@ public class HakemuksetConverterUtilTest {
         List<SuoritusJaArvosanat> suoritukset = new ArrayList<SuoritusJaArvosanat>() {{
             add(vahvistamatonLukioKeskeytynytHakukaudella);
         }};
-        Assert.assertEquals(PohjakoulutusToinenAste.YLIOPPILAS, HakemuksetConverterUtil.pohjakoulutus(haku, h, suoritukset).get());
+        Assert.assertEquals(PohjakoulutusToinenAste.PERUSKOULU, HakemuksetConverterUtil.pohjakoulutus(haku, h, suoritukset).get());
     }
 
     @Test
@@ -433,13 +438,14 @@ public class HakemuksetConverterUtilTest {
     }
 
     @Test
-    public void pohjakoulutusLukioJosHakemuksellaLukioJaEiLukioSuoritusKeskeytynytHakukaudella() {
+    public void pohjakoulutusLukioJosHakemuksellaLukioJaLoytyyValmisLukiosuoritus() {
         HakemusDTO h = new HakemusDTO();
         h.setAvaimet(new ArrayList<AvainArvoDTO>() {{
             this.add(new AvainArvoDTO("POHJAKOULUTUS", PohjakoulutusToinenAste.YLIOPPILAS));
         }});
         List<SuoritusJaArvosanat> suoritukset = new ArrayList<SuoritusJaArvosanat>() {{
             add(vahvistettuPerusopetusValmisHakukaudella);
+            add(vahvistettuLukioValmisHakukaudella);
         }};
         Assert.assertEquals(PohjakoulutusToinenAste.YLIOPPILAS, HakemuksetConverterUtil.pohjakoulutus(haku, h, suoritukset).get());
     }


### PR DESCRIPTION
Jos hakemuksella pohjakoulutuksena lukio, tarkistetaan että
suresta löytyy valmis ja vahvistettu lukiosuoritus. Jos ei,
tulkitaan pohjakoulutukseksi peruskoulu.