### PR TITLE
Bug 2034

### DIFF
--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/suoritusrekisteri/impl/SuoritusrekisteriAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/suoritusrekisteri/impl/SuoritusrekisteriAsyncResourceImpl.java
@@ -112,11 +112,6 @@ public class SuoritusrekisteriAsyncResourceImpl extends UrlConfiguredResource im
         // Add the elements returned by each response to one master list
         Observable<List<Oppija>> allOppijas = Observable
             .concat(obses);
-
-        allOppijas.subscribe(l -> {
-            LOG.info("Finished batched POST with {} results", l.size());
-        });
-
         return allOppijas;
     }
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
@@ -302,16 +302,12 @@ public class LaskentaActorFactory {
         }
 
         Observable<List<Oppija>> oppijasForOidsFromHakemukses = hakemukset.switchMap(hws -> {
-            List<String> goo = hws.stream().map(HakemusWrapper::getPersonOid).collect(Collectors.toList());
-            LOG.info("Got personOids from hakemukses and getting oppijas for these: {} for haku {}", goo.toString(), hakuOid);
-            Observable<List<Oppija>> o = suoritusrekisteriAsyncResource.getSuorituksetByOppijas(goo, hakuOid);
-            if (o != null) {
-                return o;
-            } else {
-                //todo cleanup needed. Maybe only really relevant for tests. Still, needs some love.
-                LOG.error("A null observable was returned. Not cool. Defaulting to an empty one.");
-                return Observable.just(Collections.emptyList());
-            }
+            List<String> oppijaOids = hws.stream().map(HakemusWrapper::getPersonOid).collect(Collectors.toList());
+            LOG.info("Got personOids from hakemukses and getting Oppijas for these: {} for haku {}", oppijaOids.toString(), hakuOid);
+            return createResurssiObservable(tunniste,
+                    "suoritusrekisteriAsyncResource.getSuorituksetByOppijas",
+                    suoritusrekisteriAsyncResource.getSuorituksetByOppijas(oppijaOids, hakuOid),
+                    retryHakemuksetAndOppijat);
         });
 
         Observable<List<ValintaperusteetDTO>> valintaperusteet = createResurssiObservable(tunniste,

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
@@ -303,7 +303,7 @@ public class LaskentaActorFactory {
 
         Observable<List<Oppija>> oppijasForOidsFromHakemukses = hakemukset.switchMap(hws -> {
             List<String> oppijaOids = hws.stream().map(HakemusWrapper::getPersonOid).collect(Collectors.toList());
-            LOG.info("Got personOids from hakemukses and getting Oppijas for these: {} for haku {}", oppijaOids.toString(), hakuOid);
+            LOG.info("Got personOids from hakemukses and getting Oppijas for these: {} for hakukohde {}", oppijaOids.toString(), hakukohdeOid);
             return createResurssiObservable(tunniste,
                     "suoritusrekisteriAsyncResource.getSuorituksetByOppijas",
                     suoritusrekisteriAsyncResource.getSuorituksetByOppijas(oppijaOids, hakuOid),

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
@@ -313,10 +313,6 @@ public class LaskentaActorFactory {
         Observable<List<ValintaperusteetDTO>> valintaperusteet = createResurssiObservable(tunniste,
             "valintaperusteetAsyncResource.haeValintaperusteet",
             valintaperusteetAsyncResource.haeValintaperusteet(hakukohdeOid, actorParams.getValinnanvaihe()));
-        /*Observable<List<Oppija>> oppijat = createResurssiObservable(tunniste,
-            "suoritusrekisteriAsyncResource.getOppijatByHakukohde",
-            suoritusrekisteriAsyncResource.getOppijatByHakukohde(hakukohdeOid, hakuOid),
-            retryHakemuksetAndOppijat);*/
         Observable<Map<String, List<String>>> hakukohdeRyhmasForHakukohdes = createResurssiObservable(tunniste,
             "tarjontaAsyncResource.hakukohdeRyhmasForHakukohdes",
             tarjontaAsyncResource.hakukohdeRyhmasForHakukohdes(hakuOid));

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/LaskentaActorFactory.java
@@ -39,11 +39,7 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -291,13 +287,40 @@ public class LaskentaActorFactory {
         final String hakuOid = haku.getOid();
 
         PyynnonTunniste tunniste = new PyynnonTunniste("Please put individual resource source identifier here!", uuid, hakukohdeOid);
+
+        Observable<List<HakemusWrapper>> hakemukset;
+        if (StringUtils.isNotEmpty(haku.getAtaruLomakeAvain())) {
+            hakemukset = createResurssiObservable(tunniste,
+                    "applicationAsyncResource.getApplications",
+                    ataruAsyncResource.getApplicationsByHakukohde(hakukohdeOid),
+                    retryHakemuksetAndOppijat);
+        } else {
+            hakemukset = createResurssiObservable(tunniste,
+                    "applicationAsyncResource.getApplicationsByOid",
+                    applicationAsyncResource.getApplicationsByOid(hakuOid, hakukohdeOid),
+                    retryHakemuksetAndOppijat);
+        }
+
+        Observable<List<Oppija>> oppijasForOidsFromHakemukses = hakemukset.switchMap(hws -> {
+            List<String> goo = hws.stream().map(HakemusWrapper::getPersonOid).collect(Collectors.toList());
+            LOG.info("Got personOids from hakemukses and getting oppijas for these: {} for haku {}", goo.toString(), hakuOid);
+            Observable<List<Oppija>> o = suoritusrekisteriAsyncResource.getSuorituksetByOppijas(goo, hakuOid);
+            if (o != null) {
+                return o;
+            } else {
+                //todo cleanup needed. Maybe only really relevant for tests. Still, needs some love.
+                LOG.error("A null observable was returned. Not cool. Defaulting to an empty one.");
+                return Observable.just(Collections.emptyList());
+            }
+        });
+
         Observable<List<ValintaperusteetDTO>> valintaperusteet = createResurssiObservable(tunniste,
             "valintaperusteetAsyncResource.haeValintaperusteet",
             valintaperusteetAsyncResource.haeValintaperusteet(hakukohdeOid, actorParams.getValinnanvaihe()));
-        Observable<List<Oppija>> oppijat = createResurssiObservable(tunniste,
+        /*Observable<List<Oppija>> oppijat = createResurssiObservable(tunniste,
             "suoritusrekisteriAsyncResource.getOppijatByHakukohde",
             suoritusrekisteriAsyncResource.getOppijatByHakukohde(hakukohdeOid, hakuOid),
-            retryHakemuksetAndOppijat);
+            retryHakemuksetAndOppijat);*/
         Observable<Map<String, List<String>>> hakukohdeRyhmasForHakukohdes = createResurssiObservable(tunniste,
             "tarjontaAsyncResource.hakukohdeRyhmasForHakukohdes",
             tarjontaAsyncResource.hakukohdeRyhmasForHakukohdes(hakuOid));
@@ -308,21 +331,8 @@ public class LaskentaActorFactory {
             "valintaperusteetAsyncResource.haeHakijaryhmat",
             valintaperusteetAsyncResource.haeHakijaryhmat(hakukohdeOid)) : just(emptyList());
 
-        if (StringUtils.isNotEmpty(haku.getAtaruLomakeAvain())) {
-            Observable<List<HakemusWrapper>> hakemukset = createResurssiObservable(tunniste,
-                    "applicationAsyncResource.getApplications",
-                    ataruAsyncResource.getApplicationsByHakukohde(hakukohdeOid),
-                    retryHakemuksetAndOppijat);
-            LOG.info("(Uuid: {}) Odotetaan kaikkien resurssihakujen valmistumista hakukohteelle {}, jotta voidaan palauttaa ne yhtenä pakettina.", uuid, hakukohdeOid);
-            return getLaskeDTOObservable(uuid, haku, hakukohdeOid, actorParams, withHakijaRyhmat, valintaperusteet, oppijat, hakukohdeRyhmasForHakukohdes, valintapisteetForHakukohdes, hakijaryhmat, hakemukset);
-        } else {
-            Observable<List<HakemusWrapper>> hakemukset = createResurssiObservable(tunniste,
-                "applicationAsyncResource.getApplicationsByOid",
-                applicationAsyncResource.getApplicationsByOid(hakuOid, hakukohdeOid),
-                retryHakemuksetAndOppijat);
-            LOG.info("(Uuid: {}) Odotetaan kaikkien resurssihakujen valmistumista hakukohteelle {}, jotta voidaan palauttaa ne yhtenä pakettina.", uuid, hakukohdeOid);
-            return getLaskeDTOObservable(uuid, haku, hakukohdeOid, actorParams, withHakijaRyhmat, valintaperusteet, oppijat, hakukohdeRyhmasForHakukohdes, valintapisteetForHakukohdes, hakijaryhmat, hakemukset);
-        }
+        LOG.info("(Uuid: {}) Odotetaan kaikkien resurssihakujen valmistumista hakukohteelle {}, jotta voidaan palauttaa ne yhtenä pakettina.", uuid, hakukohdeOid);
+        return getLaskeDTOObservable(uuid, haku, hakukohdeOid, actorParams, withHakijaRyhmat, valintaperusteet, oppijasForOidsFromHakemukses, hakukohdeRyhmasForHakukohdes, valintapisteetForHakukohdes, hakijaryhmat, hakemukset);
     }
 
     private <T> Observable<T> createResurssiObservable(PyynnonTunniste tunniste, String resurssi, Observable<T> sourceObservable, boolean retry) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
@@ -51,9 +51,17 @@ public class HakemuksetConverterUtil {
     private static void tryToMergeKeysOfOppijaAndHakemus(HakuV1RDTO haku, String hakukohdeOid, ParametritDTO parametritDTO, Boolean fetchEnsikertalaisuus, Map<String, Exception> errors, Map<String, Oppija> personOidToOppija, Map<String, Boolean> hasHetu, HakemusDTO h) {
         try {
             String personOid = h.getHakijaOid();
+            LOG.info(String.format("BUG-2034 : tryToMergeKeysOfOppijaAndHakemus : käsitellään hakemus %s , hakijaOid == %s", h.getHakemusoid(), personOid));
+            LOG.info(String.format("BUG-2034 : personOidToOppija.size() == %d", personOidToOppija.size()));
+            LOG.info(String.format("BUG-2034 : personOidToOppija.get(personOid) == %s", personOidToOppija.get(personOid)));
             if (personOidToOppija.containsKey(personOid)) {
                 Oppija oppija = personOidToOppija.get(personOid);
                 mergeKeysOfOppijaAndHakemus(hasHetu.get(h.getHakemusoid()), haku, hakukohdeOid, parametritDTO, errors, oppija, h, fetchEnsikertalaisuus);
+            } else {
+                LOG.info(String.format("BUG-2034 : Ei löytynyt oppijanumerolla %s. Mapin sisältö:", personOid));
+                personOidToOppija.forEach((avain, oppija) -> {
+                    LOG.info(String.format("\tBUG-2034 personOidToOppija.forEach: %s - >%s", avain, oppija));
+                });
             }
         } catch (Exception e) {
             errors.put(h.getHakemusoid(), e);
@@ -74,8 +82,13 @@ public class HakemuksetConverterUtil {
     private static List<HakemusDTO> getHakemusDTOS(HakuV1RDTO haku, String hakukohdeOid, List<Oppija> oppijat, ParametritDTO parametritDTO, Boolean fetchEnsikertalaisuus, List<HakemusDTO> hakemusDtot, Map<String, Boolean> hasHetu, Map<String, Exception> errors) {
         try {
             if (oppijat != null) {
+                LOG.info(String.format("Got %d oppijat is in getHakemusDTOS for haku %s (\"%s\"), hakukohde %s for %d applications.",
+                        oppijat.size(), haku.getOid(), haku.getNimi(), hakukohdeOid, hakemusDtot.size()));
                 Map<String, Oppija> personOidToOppija = oppijat.stream().collect(toMap(Oppija::getOppijanumero, Function.identity()));
                 hakemusDtot.forEach(h -> tryToMergeKeysOfOppijaAndHakemus(haku, hakukohdeOid, parametritDTO, fetchEnsikertalaisuus, errors, personOidToOppija, hasHetu, h));
+            } else {
+                LOG.warn(String.format("oppijat is null when calling getHakemusDTOS for haku %s (\"%s\"), hakukohde %s for %d applications.",
+                        haku.getOid(), haku.getNimi(), hakukohdeOid, hakemusDtot.size()));
             }
         } catch (Exception e) {
             LOG.error("SURE arvosanojen konversiossa (hakukohde=" + hakukohdeOid + ") odottamaton virhe", e);

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/util/HakemuksetConverterUtil.java
@@ -51,17 +51,11 @@ public class HakemuksetConverterUtil {
     private static void tryToMergeKeysOfOppijaAndHakemus(HakuV1RDTO haku, String hakukohdeOid, ParametritDTO parametritDTO, Boolean fetchEnsikertalaisuus, Map<String, Exception> errors, Map<String, Oppija> personOidToOppija, Map<String, Boolean> hasHetu, HakemusDTO h) {
         try {
             String personOid = h.getHakijaOid();
-            LOG.info(String.format("BUG-2034 : tryToMergeKeysOfOppijaAndHakemus : käsitellään hakemus %s , hakijaOid == %s", h.getHakemusoid(), personOid));
-            LOG.info(String.format("BUG-2034 : personOidToOppija.size() == %d", personOidToOppija.size()));
-            LOG.info(String.format("BUG-2034 : personOidToOppija.get(personOid) == %s", personOidToOppija.get(personOid)));
             if (personOidToOppija.containsKey(personOid)) {
                 Oppija oppija = personOidToOppija.get(personOid);
                 mergeKeysOfOppijaAndHakemus(hasHetu.get(h.getHakemusoid()), haku, hakukohdeOid, parametritDTO, errors, oppija, h, fetchEnsikertalaisuus);
             } else {
-                LOG.info(String.format("BUG-2034 : Ei löytynyt oppijanumerolla %s. Mapin sisältö:", personOid));
-                personOidToOppija.forEach((avain, oppija) -> {
-                    LOG.info(String.format("\tBUG-2034 personOidToOppija.forEach: %s - >%s", avain, oppija));
-                });
+                LOG.warn(String.format("BUG-2034 : Oppijatietoa ei löytynyt oppijanumerolla %s.", personOid));
             }
         } catch (Exception e) {
             errors.put(h.getHakemusoid(), e);

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
@@ -133,6 +133,8 @@ public class ValintalaskentaTest {
         when(suoritusrekisteriAsyncResource.getOppijatByHakukohde(ataruHakukohdeOid2, ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(new Oppija())));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of(personOid1), ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of(personOid1), hakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of("personOid"), ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of("personOid"), hakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(Collections.emptyList(), ataruHakuOid)).thenReturn(Observable.just(Collections.emptyList()));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(Collections.emptyList(), hakuOid)).thenReturn(Observable.just(Collections.emptyList()));
 

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
@@ -85,6 +85,7 @@ public class ValintalaskentaTest {
     private final HakuV1RDTO hakuDTO = new HakuV1RDTO();
     private final HakuV1RDTO ataruHakuDTO = new HakuV1RDTO();
     private final Oppija oppijaFromSure1 = new Oppija();
+    private final Oppija anonOppijaFromSure = new Oppija();
     private final List<HakukohdeJaOrganisaatio> hakukohdeJaOrganisaatios = Arrays.asList(
         new HakukohdeJaOrganisaatio(hakukohde1Oid, "o1"),
         new HakukohdeJaOrganisaatio(hakukohde2Oid, "o2"),
@@ -104,6 +105,7 @@ public class ValintalaskentaTest {
         ataruHakuDTO.setAtaruLomakeAvain("ataru-lomake-avain");
         ataruHakemus.setPersonOid(personOid1);
         oppijaFromSure1.setOppijanumero(personOid1);
+        anonOppijaFromSure.setOppijanumero("personOid");
         pisteet = new PisteetWithLastModified(Optional.empty(), Collections.singletonList
             (new Valintapisteet(hakemus.getOid(), hakemus.getPersonOid(), "Frank", "Tester", Collections.emptyList())));
 
@@ -133,8 +135,8 @@ public class ValintalaskentaTest {
         when(suoritusrekisteriAsyncResource.getOppijatByHakukohde(ataruHakukohdeOid2, ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(new Oppija())));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of(personOid1), ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of(personOid1), hakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
-        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of("personOid"), ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
-        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of("personOid"), hakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of("personOid"), ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(anonOppijaFromSure)));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of("personOid"), hakuOid)).thenReturn(Observable.just(Collections.singletonList(anonOppijaFromSure)));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(Collections.emptyList(), ataruHakuOid)).thenReturn(Observable.just(Collections.emptyList()));
         when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(Collections.emptyList(), hakuOid)).thenReturn(Observable.just(Collections.emptyList()));
 

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/ValintalaskentaTest.java
@@ -81,8 +81,10 @@ public class ValintalaskentaTest {
     private final String uuid = "uuid";
     private final String hakuOid = "hakuOid";
     private final String ataruHakuOid = "1.2.246.562.29.805206009510";
+    private final String personOid1 = "1.2.246.562.24.86368188549";
     private final HakuV1RDTO hakuDTO = new HakuV1RDTO();
     private final HakuV1RDTO ataruHakuDTO = new HakuV1RDTO();
+    private final Oppija oppijaFromSure1 = new Oppija();
     private final List<HakukohdeJaOrganisaatio> hakukohdeJaOrganisaatios = Arrays.asList(
         new HakukohdeJaOrganisaatio(hakukohde1Oid, "o1"),
         new HakukohdeJaOrganisaatio(hakukohde2Oid, "o2"),
@@ -100,7 +102,8 @@ public class ValintalaskentaTest {
         hakuDTO.setOid(hakuOid);
         ataruHakuDTO.setOid(ataruHakuOid);
         ataruHakuDTO.setAtaruLomakeAvain("ataru-lomake-avain");
-        ataruHakemus.setPersonOid("1.2.246.562.24.86368188549");
+        ataruHakemus.setPersonOid(personOid1);
+        oppijaFromSure1.setOppijanumero(personOid1);
         pisteet = new PisteetWithLastModified(Optional.empty(), Collections.singletonList
             (new Valintapisteet(hakemus.getOid(), hakemus.getPersonOid(), "Frank", "Tester", Collections.emptyList())));
 
@@ -128,6 +131,10 @@ public class ValintalaskentaTest {
         when(suoritusrekisteriAsyncResource.getOppijatByHakukohde(hakukohde3Oid, hakuOid)).thenReturn(Observable.just(Collections.singletonList(new Oppija())));
         when(suoritusrekisteriAsyncResource.getOppijatByHakukohde(ataruHakukohdeOid, ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(new Oppija())));
         when(suoritusrekisteriAsyncResource.getOppijatByHakukohde(ataruHakukohdeOid2, ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(new Oppija())));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of(personOid1), ataruHakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(List.of(personOid1), hakuOid)).thenReturn(Observable.just(Collections.singletonList(oppijaFromSure1)));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(Collections.emptyList(), ataruHakuOid)).thenReturn(Observable.just(Collections.emptyList()));
+        when(suoritusrekisteriAsyncResource.getSuorituksetByOppijas(Collections.emptyList(), hakuOid)).thenReturn(Observable.just(Collections.emptyList()));
 
         when(tarjontaAsyncResource.hakukohdeRyhmasForHakukohdes(hakuOid)).thenReturn(Observable.just(Collections.emptyMap()));
         when(tarjontaAsyncResource.hakukohdeRyhmasForHakukohdes(ataruHakuOid)).thenReturn(Observable.just(Collections.emptyMap()));
@@ -165,6 +172,7 @@ public class ValintalaskentaTest {
         when(seurantaAsyncResource.merkkaaHakukohteenTila(uuid, ataruHakukohdeOid2, HakukohdeTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.merkkaaLaskennanTila(uuid, LaskentaTila.VALMIS, Optional.empty())).thenReturn(Observable.just(Response.noContent().build()));
         when(seurantaAsyncResource.otaSeuraavaLaskentaTyonAlle()).thenReturn(Observable.just(Optional.empty()));
+
 
         LaskentaStartParams laskentaJaHaku = new LaskentaStartParams(auditSession, uuid, ataruHakuOid, false, null, null, ataruHakukohdeJaOrganisaatios, LaskentaTyyppi.HAKUKOHDE);
 


### PR DESCRIPTION
Kun on ensin haettu hakemukset atarusta/haku-appista, haetaan suresta oppija-tiedot niiltä löytyville henkilöOideille. Ennen haettiin "tietyn hakukohteen hakijoille". Tämä ratkaisee aiemman ongelman, jossa sure saattoi linkitettyjen henkilöiden tapauksessa palauttaa tiedot eri henkilöOidille kuin mikä löytyi hakemukselta, jolloin tietoja ei saatu myöhemmin yhdistettyä.