### PR TITLE
PistesyottoE2ETest -korjausyritys

### DIFF
--- a/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoE2ETest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoE2ETest.java
@@ -165,6 +165,7 @@ public class PistesyottoE2ETest extends PistesyotonTuontiTestBase {
                     Assert.assertEquals("Pisteitä tallennetaan ilmeisesti paljon.", 43681, count);
                     exchange.sendResponseHeaders(200, 0);
                     exchange.getResponseBody().write(gson().toJson(Collections.emptySet()).getBytes());
+                    exchange.getResponseBody().flush();
                     exchange.close();
                 } finally {
                     counter.release();
@@ -198,6 +199,7 @@ public class PistesyottoE2ETest extends PistesyotonTuontiTestBase {
             fakeValintaPisteService.addHandler("/valintapiste-service/api/pisteet-with-hakemusoids", exchange -> {
                 exchange.sendResponseHeaders(200, 0);
                 exchange.getResponseBody().write(gson().toJson(Collections.emptySet()).getBytes());
+                exchange.getResponseBody().flush();
                 exchange.close();
                 counter.release();
             }));

--- a/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoKoosteE2ETest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/pistesyotto/excel/PistesyottoKoosteE2ETest.java
@@ -425,7 +425,7 @@ public class PistesyottoKoosteE2ETest extends PistesyotonTuontiTestBase {
             fakeValintaPisteService.addHandler("/valintapiste-service/api/pisteet-with-hakemusoids", exchange -> {
                 exchange.sendResponseHeaders(200, 0);
                 exchange.getResponseBody().write(gson().toJson(Collections.emptySet()).getBytes());
-                exchange.getResponseBody().close();
+                exchange.getResponseBody().flush();
                 exchange.close();
                 counter.release();
             }));
@@ -442,7 +442,7 @@ public class PistesyottoKoosteE2ETest extends PistesyotonTuontiTestBase {
                 assertEquals("Paljon pisteitä viedään", 1057 - n, count);
                 exchange.sendResponseHeaders(200, 0);
                 exchange.getResponseBody().write(gson().toJson(Collections.emptySet()).getBytes());
-                exchange.getResponseBody().close();
+                exchange.getResponseBody().flush();
                 exchange.close();
                 counter.release();
             }));


### PR DESCRIPTION
Virhe, joka tulee, on tällainen

```
java.io.IOException: Connection reset by peer
        at java.base/sun.nio.ch.FileDispatcherImpl.read0(Native Method)
        at java.base/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:39)
        at java.base/sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:276)
        at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:245)
        at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:223)
        at java.base/sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:358)
        at io.netty.buffer.UnpooledHeapByteBuf.setBytes(UnpooledHeapByteBuf.java:256)
        at io.netty.buffer.AbstractByteBuf.writeBytes(AbstractByteBuf.java:881)
        at io.netty.channel.socket.nio.NioSocketChannel.doReadBytes(NioSocketChannel.java:241)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:119)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:511)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:468)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:382)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:354)
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:111)
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

Ainakin omalla koneellani testi feilasi aika säännönmukaisesti ennen kuin lisäsin mock-serverin vastaukseen vastausstreamin flushauksen. Vaikuttaisi siltä, että close on tullut ennen kuin clientti on ehtinyt lukea vastausta kokonaan.