### PR TITLE
VTKU-110 : ammatillisten arvosanojen leikkuripvm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <sijoittelu.version>7.4.0-SNAPSHOT</sijoittelu.version>
         <valinta-sharedutils.version>5.11-SNAPSHOT</valinta-sharedutils.version>
-        <valintaperusteet.version>5.13-VTKU-110-SNAPSHOT</valintaperusteet.version>
-        <valintalaskenta.version>5.14-VTKU-110-SNAPSHOT</valintalaskenta.version>
+        <valintaperusteet.version>5.13-SNAPSHOT</valintaperusteet.version>
+        <valintalaskenta.version>5.14-SNAPSHOT</valintalaskenta.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -15,19 +15,19 @@
         <camel.version>2.12.1</camel.version>
         <jsch.version>0.1.55</jsch.version>
         <fake-sftp-server-rule.version>2.0.1</fake-sftp-server-rule.version>
-        <cxf.version>3.3.2</cxf.version>
-        <fasterxml.jackson.version>2.10.2</fasterxml.jackson.version>
-        <jetty.version>9.4.15.v20190215</jetty.version>
+        <cxf.version>3.3.5</cxf.version>
+        <fasterxml.jackson.version>2.10.3</fasterxml.jackson.version>
+        <jetty.version>9.4.27.v20200227</jetty.version>
         <kela.version>12.0-SNAPSHOT</kela.version>
         <slf4j.version>1.7.28</slf4j.version>
-        <spring.security.version>5.1.4.RELEASE</spring.security.version>
-        <spring.version>5.1.5.RELEASE</spring.version>
+        <spring.security.version>5.1.8.RELEASE</spring.security.version>
+        <spring.version>5.1.14.RELEASE</spring.version>
         <jaxb.version>2.3.0</jaxb.version>
         <mockito.version>2.24.0</mockito.version>
 
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <sijoittelu.version>7.4.0-SNAPSHOT</sijoittelu.version>
-        <valinta-sharedutils.version>5.10-SNAPSHOT</valinta-sharedutils.version>
+        <valinta-sharedutils.version>5.11-SNAPSHOT</valinta-sharedutils.version>
         <valintaperusteet.version>5.13-VTKU-110-SNAPSHOT</valintaperusteet.version>
         <valintalaskenta.version>5.14-VTKU-110-SNAPSHOT</valintalaskenta.version>
     </properties>
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>fi.vm.sade.java-utils</groupId>
                 <artifactId>java-cxf</artifactId>
-                <version>0.3.3-SNAPSHOT</version>
+                <version>0.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>fi.vm.sade.java-utils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <sijoittelu.version>7.4.0-SNAPSHOT</sijoittelu.version>
         <valinta-sharedutils.version>5.10-SNAPSHOT</valinta-sharedutils.version>
-        <valintaperusteet.version>5.12-SNAPSHOT</valintaperusteet.version>
-        <valintalaskenta.version>5.13-SNAPSHOT</valintalaskenta.version>
+        <valintaperusteet.version>5.13-VTKU-110-SNAPSHOT</valintaperusteet.version>
+        <valintalaskenta.version>5.14-VTKU-110-SNAPSHOT</valintalaskenta.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiAsyncResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiAsyncResource.java
@@ -1,9 +1,12 @@
 package fi.vm.sade.valinta.kooste.external.resource.koski;
 
+import com.google.gson.JsonElement;
+
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public interface KoskiAsyncResource {
     CompletableFuture<Set<KoskiOppija>> findKoskiOppijat(List<String> oppijanumerot);
+    CompletableFuture<JsonElement> findVersionOfOpiskeluoikeus(String opiskeluoikeudenOid, int versionumero);
 }

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
@@ -31,7 +31,11 @@ public class KoskiOppija {
         this.henkilö = henkilö;
     }
 
-    public JsonArray haeOpiskeluoikeudet(Set<String> koskenOpiskeluoikeusTyypit) {
+    public void poistaMuuntyyppisetOpiskeluoikeudetKuin(Set<String> kiinnostavatOpiskeluoikeusTyypit) {
+        setOpiskeluoikeudet(haeOpiskeluoikeudet(kiinnostavatOpiskeluoikeusTyypit));
+    }
+
+    private JsonArray haeOpiskeluoikeudet(Set<String> koskenOpiskeluoikeusTyypit) {
         if (opiskeluoikeudet == null) {
             return null;
         }

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
@@ -101,9 +101,6 @@ public class KoskiOppija {
         }
 
         public static int versionumero(JsonElement opiskeluoikeus) {
-            if (opiskeluoikeus == null) {
-                return -1;
-            }
             return opiskeluoikeus.getAsJsonObject().get("versionumero").getAsInt();
         }
     }

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
@@ -8,8 +8,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 public class KoskiOppija {
@@ -44,22 +42,6 @@ public class KoskiOppija {
             }
         });
         return tulos;
-    }
-
-    public Set<JsonElement> opiskeluoikeudetJotkaOvatUudempiaKuin(LocalDate leikkuriPvm, Set<String> koskenOpiskeluoikeusTyypit) {
-        if (opiskeluoikeudet == null || opiskeluoikeudet.isJsonNull() || opiskeluoikeudet.size() == 0) {
-            return Collections.emptySet();
-        }
-
-        Set<JsonElement> tulokset = new HashSet<>();
-        for (JsonElement opiskeluoikeus : opiskeluoikeudet) {
-            if (koskenOpiskeluoikeusTyypit.contains(OpiskeluoikeusJsonUtil.tyypinKoodiarvo(opiskeluoikeus))) {
-                if (OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, opiskeluoikeus)) {
-                    tulokset.add(opiskeluoikeus);
-                }
-            }
-        }
-        return tulokset;
     }
 
     public static class KoskiHenkilö {

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Set;
 
 public class KoskiOppija {
@@ -63,7 +65,10 @@ public class KoskiOppija {
     }
 
     public static class OpiskeluoikeusJsonUtil {
-        private static final DateTimeFormatter OPISKELUOIKEUDEN_AIKALEIMA_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
+        private static final DateTimeFormatter OPISKELUOIKEUDEN_AIKALEIMA_FORMAT = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .toFormatter();
 
         public static String tyypinKoodiarvo(JsonElement opiskeluoikeus) {
             return opiskeluoikeus.getAsJsonObject().get("tyyppi").getAsJsonObject().get("koodiarvo").getAsString();

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppija.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public class KoskiOppija {
@@ -44,18 +46,20 @@ public class KoskiOppija {
         return tulos;
     }
 
-    public boolean sisaltaaUudempiaOpiskeluoikeuksiaKuin(LocalDate leikkuriPvm, Set<String> koskenOpiskeluoikeusTyypit) {
+    public Set<JsonElement> opiskeluoikeudetJotkaOvatUudempiaKuin(LocalDate leikkuriPvm, Set<String> koskenOpiskeluoikeusTyypit) {
         if (opiskeluoikeudet == null || opiskeluoikeudet.isJsonNull() || opiskeluoikeudet.size() == 0) {
-            return false;
+            return Collections.emptySet();
         }
+
+        Set<JsonElement> tulokset = new HashSet<>();
         for (JsonElement opiskeluoikeus : opiskeluoikeudet) {
             if (koskenOpiskeluoikeusTyypit.contains(OpiskeluoikeusJsonUtil.tyypinKoodiarvo(opiskeluoikeus))) {
                 if (OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, opiskeluoikeus)) {
-                    return true;
+                    tulokset.add(opiskeluoikeus);
                 }
             }
         }
-        return false;
+        return tulokset;
     }
 
     public static class KoskiHenkilö {

--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/impl/KoskiAsyncResourceImpl.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/koski/impl/KoskiAsyncResourceImpl.java
@@ -1,6 +1,7 @@
 package fi.vm.sade.valinta.kooste.external.resource.koski.impl;
 
 import com.google.common.collect.Lists;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 
@@ -62,6 +63,15 @@ public class KoskiAsyncResourceImpl implements KoskiAsyncResource {
     public CompletableFuture<Set<KoskiOppija>> findKoskiOppijat(List<String> oppijanumerot) {
         return batchedPostOppijasFuture(oppijanumerot, urlConfiguration.url("koski.oppijanumeroittain.post"))
             .whenComplete(debugLogOpiskeluoikeusVersiot());
+    }
+
+    @Override
+    public CompletableFuture<JsonElement> findVersionOfOpiskeluoikeus(String opiskeluoikeudenOid, int versionumero) {
+        return httpClient.getResponse(
+            urlConfiguration.url("koski.opiskeluoikeuden.versio", opiskeluoikeudenOid, versionumero),
+            Duration.ofMinutes(1),
+            addBasicAuthenticationCredentials
+        ).thenApplyAsync(r -> httpClient.parseJson(r, JsonElement.class));
     }
 
     private CompletableFuture<Set<KoskiOppija>> batchedPostOppijasFuture(List<String> oppijanumerot, String url) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
@@ -85,7 +85,7 @@ public class KoskiOpiskeluoikeusHistoryService {
         return tulokset;
     }
 
-    void haeUusimmatLeikkuripaivaaEdeltavatOpiskeluoikeudetTarvittaessa(Set<KoskiOppija> koskioppijat, LocalDate leikkuriPvm) {
+    void haeVanhemmatOpiskeluoikeudetTarvittaessa(Set<KoskiOppija> koskioppijat, LocalDate leikkuriPvm) {
         koskioppijat.forEach(koskiOppija -> {
             final Set<JsonElement> liianUudetOpiskeluoikeudet = koskiOppija.opiskeluoikeudetJotkaOvatUudempiaKuin(leikkuriPvm, koskenOpiskeluoikeusTyypit);
             if (!liianUudetOpiskeluoikeudet.isEmpty()) {
@@ -109,7 +109,8 @@ public class KoskiOpiskeluoikeusHistoryService {
                     opiskeluoikeudenOid,
                     aikaleima,
                     FINNISH_DATE_FORMAT.format(leikkuriPvm)));
-                haePaivamaaranMukainenVersio(koskiOppija, leikkuriPvm, opiskeluoikeus).ifPresent(tulokset::add);
+                haePaivamaaranMukainenVersio(koskiOppija, leikkuriPvm, opiskeluoikeus)
+                    .ifPresent(tulokset::add);
             } else {
                 tulokset.add(opiskeluoikeus);
             }

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
@@ -38,12 +38,10 @@ public class KoskiOpiskeluoikeusHistoryService {
 
     private static final DateTimeFormatter FINNISH_DATE_FORMAT = DateTimeFormatter.ofPattern("d.M.yyyy");
     private final KoskiAsyncResource koskiAsyncResource;
-    private final Set<String> koskenOpiskeluoikeusTyypit;
 
     @Autowired
-    public KoskiOpiskeluoikeusHistoryService(Set<String> koskenOpiskeluoikeusTyypit, KoskiAsyncResource koskiAsyncResource) {
+    public KoskiOpiskeluoikeusHistoryService(KoskiAsyncResource koskiAsyncResource) {
         this.koskiAsyncResource = koskiAsyncResource;
-        this.koskenOpiskeluoikeusTyypit = koskenOpiskeluoikeusTyypit;
     }
 
     LocalDate etsiKoskiDatanLeikkuriPvm(List<ValintaperusteetDTO> valintaperusteetDTOS, String hakukohdeOid) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
@@ -106,12 +106,14 @@ public class KoskiOpiskeluoikeusHistoryService {
     private CompletableFuture<JsonArray> haeOpiskeluoikeuksistaPaivanMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm) {
         return CompletableFutureUtil.sequence(Lists.newArrayList(koskiOppija.getOpiskeluoikeudet()).stream().map(opiskeluoikeus -> {
             if (OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, opiskeluoikeus)) {
-                LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
                 String opiskeluoikeudenOid = OpiskeluoikeusJsonUtil.oid(opiskeluoikeus);
-                LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s aikaleima on %s eli leikkuripäivämäärän %s jälkeen." +
+                int versionumero = OpiskeluoikeusJsonUtil.versionumero(opiskeluoikeus);
+                LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
+                LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s uusimman version %d aikaleima on %s eli leikkuripäivämäärän %s jälkeen." +
                         " Etsitään opiskeluoikeudesta versioita, jotka olisi tallennettu ennen leikkuripäivämäärää.",
                     koskiOppija.getOppijanumero(),
                     opiskeluoikeudenOid,
+                    versionumero,
                     aikaleima,
                     FINNISH_DATE_FORMAT.format(leikkuriPvm)));
                 return haePaivamaaranMukainenVersio(koskiOppija, leikkuriPvm, CompletableFuture.completedFuture(opiskeluoikeus));
@@ -131,7 +133,7 @@ public class KoskiOpiskeluoikeusHistoryService {
             LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
             String opiskeluoikeudenOid = OpiskeluoikeusJsonUtil.oid(opiskeluoikeus);
             if (!OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, aikaleima)) {
-                LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s version %d aikaleima on %s eli ennen leikkuripäivämäärää %s, joten huomioidaan tämä opiskeluoikeus.",
+                LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s version %d aikaleima on %s eli leikkuripäivämäärään %s mennessä, joten huomioidaan tämä opiskeluoikeus.",
                     koskiOppija.getOppijanumero(),
                     opiskeluoikeudenOid,
                     versionumero,

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
@@ -83,13 +83,12 @@ public class KoskiOpiskeluoikeusHistoryService {
         koskioppijat.forEach(koskiOppija ->
             koskiOppija.setOpiskeluoikeudet(haeOpiskeluoikeuksistaPaivanMukainenVersio(
                 koskiOppija,
-                leikkuriPvm,
-                koskiOppija.haeOpiskeluoikeudet(koskenOpiskeluoikeusTyypit))));
+                leikkuriPvm)));
     }
 
-    private JsonArray haeOpiskeluoikeuksistaPaivanMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm, JsonArray opiskeluoikeudet) {
+    private JsonArray haeOpiskeluoikeuksistaPaivanMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm) {
         JsonArray tulokset = new JsonArray();
-        opiskeluoikeudet.forEach(opiskeluoikeus -> {
+        koskiOppija.getOpiskeluoikeudet().forEach(opiskeluoikeus -> {
             if (OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, opiskeluoikeus)) {
                 LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
                 String opiskeluoikeudenOid = OpiskeluoikeusJsonUtil.oid(opiskeluoikeus);

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
@@ -80,15 +80,11 @@ public class KoskiOpiskeluoikeusHistoryService {
     }
 
     void haeVanhemmatOpiskeluoikeudetTarvittaessa(Set<KoskiOppija> koskioppijat, LocalDate leikkuriPvm) {
-        koskioppijat.forEach(koskiOppija -> {
-            final Set<JsonElement> liianUudetOpiskeluoikeudet = koskiOppija.opiskeluoikeudetJotkaOvatUudempiaKuin(leikkuriPvm, koskenOpiskeluoikeusTyypit);
-            if (!liianUudetOpiskeluoikeudet.isEmpty()) {
-                koskiOppija.setOpiskeluoikeudet(haeOpiskeluoikeuksistaPaivanMukainenVersio(
-                    koskiOppija,
-                    leikkuriPvm,
-                    koskiOppija.haeOpiskeluoikeudet(koskenOpiskeluoikeusTyypit)));
-            }
-        });
+        koskioppijat.forEach(koskiOppija ->
+            koskiOppija.setOpiskeluoikeudet(haeOpiskeluoikeuksistaPaivanMukainenVersio(
+                koskiOppija,
+                leikkuriPvm,
+                koskiOppija.haeOpiskeluoikeudet(koskenOpiskeluoikeusTyypit))));
     }
 
     private JsonArray haeOpiskeluoikeuksistaPaivanMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm, JsonArray opiskeluoikeudet) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
@@ -1,0 +1,147 @@
+package fi.vm.sade.valinta.kooste.valintalaskenta.actor;
+
+import static fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi.ITEROIAMMATILLISETTUTKINNOT;
+import static fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi.ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+
+import fi.vm.sade.service.valintaperusteet.dto.SyoteparametriDTO;
+import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteetDTO;
+import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteetFunktiokutsuDTO;
+import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiAsyncResource;
+import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiOppija;
+import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiOppija.OpiskeluoikeusJsonUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class KoskiOpiskeluoikeusHistoryService {
+    private static final Logger LOG = LoggerFactory.getLogger(KoskiOpiskeluoikeusHistoryService.class);
+
+    private static final DateTimeFormatter FINNISH_DATE_FORMAT = DateTimeFormatter.ofPattern("d.M.yyyy");
+    private final KoskiAsyncResource koskiAsyncResource;
+    private final Set<String> koskenOpiskeluoikeusTyypit;
+
+    @Autowired
+    public KoskiOpiskeluoikeusHistoryService(Set<String> koskenOpiskeluoikeusTyypit, KoskiAsyncResource koskiAsyncResource) {
+        this.koskiAsyncResource = koskiAsyncResource;
+        this.koskenOpiskeluoikeusTyypit = koskenOpiskeluoikeusTyypit;
+    }
+
+    LocalDate etsiKoskiDatanLeikkuriPvm(List<ValintaperusteetDTO> valintaperusteetDTOS, String hakukohdeOid) {
+        List<String> leikkuriPvmMerkkijonot = etsiTutkintojenIterointiFunktioKutsut(valintaperusteetDTOS)
+            .flatMap(tutkintojenIterointiFunktio -> tutkintojenIterointiFunktio.getSyoteparametrit().stream()
+                .filter(parametri -> ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI.equals(parametri.getAvain()) && StringUtils.isNotBlank(parametri.getArvo()))
+                .map(SyoteparametriDTO::getArvo))
+            .collect(Collectors.toList());
+        List<LocalDate> kaikkiLeikkuriPvmtValintaperusteista = leikkuriPvmMerkkijonot.stream()
+            .map(pvm -> LocalDate.parse(pvm, FINNISH_DATE_FORMAT))
+            .sorted()
+            .collect(Collectors.toList());
+        LocalDate kaytettavaLeikkuriPvm;
+        if (!kaikkiLeikkuriPvmtValintaperusteista.isEmpty()) {
+            kaytettavaLeikkuriPvm = kaikkiLeikkuriPvmtValintaperusteista.get(kaikkiLeikkuriPvmtValintaperusteista.size() - 1);
+        } else {
+            kaytettavaLeikkuriPvm = LocalDate.now();
+        }
+        LOG.info(String.format("Saatiin hakukohteen %s valintaperusteista Koski-datan leikkuripäivämäärät %s. Käytetään leikkuripäivämääränä arvoa %s.",
+            hakukohdeOid, leikkuriPvmMerkkijonot, FINNISH_DATE_FORMAT.format(kaytettavaLeikkuriPvm)));
+        return kaytettavaLeikkuriPvm;
+    }
+
+    static Stream<ValintaperusteetFunktiokutsuDTO> etsiTutkintojenIterointiFunktioKutsut(List<ValintaperusteetDTO> valintaperusteetDTOS) {
+        return valintaperusteetDTOS.stream()
+            .flatMap(valintaperusteetDTO -> valintaperusteetDTO.getValinnanVaihe().getValintatapajono().stream())
+            .flatMap(jono -> jono.getJarjestyskriteerit().stream())
+            .flatMap(kriteeri ->
+                etsiFunktiokutsutRekursiivisesti(
+                    kriteeri.getFunktiokutsu(),
+                    fk -> ITEROIAMMATILLISETTUTKINNOT.equals(fk.getFunktionimi())).stream());
+    }
+
+    static private List<ValintaperusteetFunktiokutsuDTO> etsiFunktiokutsutRekursiivisesti(ValintaperusteetFunktiokutsuDTO juuriFunktioKutsu,
+                                                                                   Predicate<ValintaperusteetFunktiokutsuDTO> predikaatti) {
+        List<ValintaperusteetFunktiokutsuDTO> tulokset = new LinkedList<>();
+        if (predikaatti.test(juuriFunktioKutsu)) {
+            tulokset.add(juuriFunktioKutsu);
+        }
+        tulokset.addAll(juuriFunktioKutsu.getFunktioargumentit().stream()
+            .flatMap(argumentti -> etsiFunktiokutsutRekursiivisesti(argumentti.getFunktiokutsu(), predikaatti).stream())
+            .collect(Collectors.toSet()));
+        return tulokset;
+    }
+
+    void haeUusimmatLeikkuripaivaaEdeltavatOpiskeluoikeudetTarvittaessa(Set<KoskiOppija> koskioppijat, LocalDate leikkuriPvm) {
+        koskioppijat.forEach(koskiOppija -> {
+            final Set<JsonElement> liianUudetOpiskeluoikeudet = koskiOppija.opiskeluoikeudetJotkaOvatUudempiaKuin(leikkuriPvm, koskenOpiskeluoikeusTyypit);
+            if (!liianUudetOpiskeluoikeudet.isEmpty()) {
+                koskiOppija.setOpiskeluoikeudet(haeOpiskeluoikeuksistaPaivanMukainenVersio(
+                    koskiOppija,
+                    leikkuriPvm,
+                    koskiOppija.haeOpiskeluoikeudet(koskenOpiskeluoikeusTyypit)));
+            }
+        });
+    }
+
+    private JsonArray haeOpiskeluoikeuksistaPaivanMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm, JsonArray opiskeluoikeudet) {
+        JsonArray tulokset = new JsonArray();
+        opiskeluoikeudet.forEach(opiskeluoikeus -> {
+            if (OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, opiskeluoikeus)) {
+                LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
+                String opiskeluoikeudenOid = OpiskeluoikeusJsonUtil.oid(opiskeluoikeus);
+                LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s aikaleima on %s eli leikkuripäivämäärän %s jälkeen." +
+                        " Etsitään opiskeluoikeudesta versioita, jotka olisi tallennettu ennen leikkuripäivämäärää.",
+                    koskiOppija.getOppijanumero(),
+                    opiskeluoikeudenOid,
+                    aikaleima,
+                    FINNISH_DATE_FORMAT.format(leikkuriPvm)));
+                haePaivamaaranMukainenVersio(koskiOppija, leikkuriPvm, opiskeluoikeus).ifPresent(tulokset::add);
+            } else {
+                tulokset.add(opiskeluoikeus);
+            }
+        });
+        return tulokset;
+    }
+
+    private Optional<JsonElement> haePaivamaaranMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm, JsonElement opiskeluoikeus) {
+        int versionumero = OpiskeluoikeusJsonUtil.versionumero(opiskeluoikeus);
+        LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
+        String opiskeluoikeudenOid = OpiskeluoikeusJsonUtil.oid(opiskeluoikeus);
+        if (!OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, aikaleima)) {
+            LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s version %d aikaleima on %s eli ennen leikkuripäivämäärää %s, joten huomioidaan tämä opiskeluoikeus.",
+                koskiOppija.getOppijanumero(),
+                opiskeluoikeudenOid,
+                versionumero,
+                aikaleima,
+                FINNISH_DATE_FORMAT.format(leikkuriPvm)
+                ));
+            return Optional.of(opiskeluoikeus);
+        }
+        if (versionumero <= 1) {
+            LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s aikaleima on %s eli leikkuripäivämäärän %s jälkeen," +
+                    " ja versio %d, joten vanhempia versioita ei ole. Jätetään opiskeluoikeus huomioimatta.",
+                koskiOppija.getOppijanumero(),
+                opiskeluoikeudenOid,
+                aikaleima,
+                FINNISH_DATE_FORMAT.format(leikkuriPvm),
+                versionumero));
+            return Optional.empty();
+        }
+        JsonElement edellisenVersionOpiskeluoikeus = koskiAsyncResource.findVersionOfOpiskeluoikeus(opiskeluoikeudenOid, versionumero - 1).join();
+        return haePaivamaaranMukainenVersio(koskiOppija, leikkuriPvm, edellisenVersionOpiskeluoikeus);
+    }
+}

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiOpiskeluoikeusHistoryService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -48,16 +49,9 @@ public class KoskiOpiskeluoikeusHistoryService {
                 .filter(parametri -> ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI.equals(parametri.getAvain()) && StringUtils.isNotBlank(parametri.getArvo()))
                 .map(SyoteparametriDTO::getArvo))
             .collect(Collectors.toList());
-        List<LocalDate> kaikkiLeikkuriPvmtValintaperusteista = leikkuriPvmMerkkijonot.stream()
+        LocalDate kaytettavaLeikkuriPvm = leikkuriPvmMerkkijonot.stream()
             .map(pvm -> LocalDate.parse(pvm, FINNISH_DATE_FORMAT))
-            .sorted()
-            .collect(Collectors.toList());
-        LocalDate kaytettavaLeikkuriPvm;
-        if (!kaikkiLeikkuriPvmtValintaperusteista.isEmpty()) {
-            kaytettavaLeikkuriPvm = kaikkiLeikkuriPvmtValintaperusteista.get(kaikkiLeikkuriPvmtValintaperusteista.size() - 1);
-        } else {
-            kaytettavaLeikkuriPvm = LocalDate.now();
-        }
+            .max(Comparator.naturalOrder()).orElse(LocalDate.now());
         LOG.info(String.format("Saatiin hakukohteen %s valintaperusteista Koski-datan leikkuripäivämäärät %s. Käytetään leikkuripäivämääränä arvoa %s.",
             hakukohdeOid, leikkuriPvmMerkkijonot, FINNISH_DATE_FORMAT.format(kaytettavaLeikkuriPvm)));
         return kaytettavaLeikkuriPvm;

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
@@ -95,7 +95,7 @@ public class KoskiService {
             .thenApplyAsync(koskioppijat -> {
                 LOG.info(String.format("Saatiin Koskesta %s uuden oppijan tiedot, kun haettiin %d/%d oppijalle (%s:lle oli jo haettu tiedot) hakukohteen %s laskemista varten.",
                     koskioppijat.size(), oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.size(), hakemusWrappers.size(), maaraJoilleTiedotJoLoytyvat, hakukohdeOid));
-                koskiOpiskeluoikeusHistoryService.haeUusimmatLeikkuripaivaaEdeltavatOpiskeluoikeudetTarvittaessa(koskioppijat, paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan);
+                koskiOpiskeluoikeusHistoryService.haeVanhemmatOpiskeluoikeudetTarvittaessa(koskioppijat, paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan);
                 Map<String, KoskiOppija> koskiOppijatOppijanumeroittain = koskioppijat.stream().collect(Collectors.toMap(KoskiOppija::getOppijanumero, Function.identity()));
                 oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.forEach(oppijanumero -> {
                     KoskiOppija loytynytOppija = koskiOppijatOppijanumeroittain.get(oppijanumero);

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
@@ -46,12 +46,13 @@ public class KoskiService {
     public KoskiService(@Value("${valintalaskentakoostepalvelu.laskenta.koskesta.haettavat.hakukohdeoidit:none}") String koskiHakukohdeOiditString,
                         @Value("${valintalaskentakoostepalvelu.laskenta.funktionimet.joille.haetaan.tiedot.koskesta}") String koskenFunktionimetString,
                         @Value("${valintalaskentakoostepalvelu.laskenta.opiskeluoikeustyypit.joille.haetaan.tiedot.koskesta}") String koskenOpiskeluoikeusTyypitString,
+                        @Value("${valintalaskentakoostepalvelu.laskenta.kosken.historiapyyntojen.rinnakkaisuus}") Integer koskenHistoriapyyntojenRinnakkaisuus,
                         KoskiAsyncResource koskiAsyncResource) {
         this.koskiAsyncResource = koskiAsyncResource;
         this.koskiHakukohdeOidFilter = resolveKoskiHakukohdeOidFilter(koskiHakukohdeOiditString);
         this.koskenFunktionimet = resolveKoskenFunktionimet(koskenFunktionimetString);
         this.koskenOpiskeluoikeusTyypit = resolveKoskenOpiskeluoikeudet(koskenOpiskeluoikeusTyypitString);
-        this.koskiOpiskeluoikeusHistoryService = new KoskiOpiskeluoikeusHistoryService(koskiAsyncResource);
+        this.koskiOpiskeluoikeusHistoryService = new KoskiOpiskeluoikeusHistoryService(koskenHistoriapyyntojenRinnakkaisuus, koskiAsyncResource);
     }
 
     /**

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
@@ -51,7 +51,7 @@ public class KoskiService {
         this.koskiHakukohdeOidFilter = resolveKoskiHakukohdeOidFilter(koskiHakukohdeOiditString);
         this.koskenFunktionimet = resolveKoskenFunktionimet(koskenFunktionimetString);
         this.koskenOpiskeluoikeusTyypit = resolveKoskenOpiskeluoikeudet(koskenOpiskeluoikeusTyypitString);
-        this.koskiOpiskeluoikeusHistoryService = new KoskiOpiskeluoikeusHistoryService(koskenOpiskeluoikeusTyypit, koskiAsyncResource);
+        this.koskiOpiskeluoikeusHistoryService = new KoskiOpiskeluoikeusHistoryService(koskiAsyncResource);
     }
 
     /**

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
@@ -85,20 +85,20 @@ public class KoskiService {
                                                                       SuoritustiedotDTO suoritustiedotDTO,
                                                                       LocalDate paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan) {
         LOG.info(String.format("Haetaan Koskesta tiedot %d oppijalle hakukohteen %s laskemista varten.", hakemusWrappers.size(), hakukohdeOid));
-        List<String> oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat = hakemusWrappers.stream()
+        List<String> oppijanumerotJoiltaKoskiOpiskeluoikeudetPuuttuvat = hakemusWrappers.stream()
             .map(HakemusWrapper::getPersonOid)
             .filter(oppijanumero -> !suoritustiedotDTO.onKoskiopiskeluoikeudet(oppijanumero))
             .collect(Collectors.toList());
-        int maaraJoilleTiedotJoLoytyvat = hakemusWrappers.size() - oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.size();
+        int maaraJoilleTiedotJoLoytyvat = hakemusWrappers.size() - oppijanumerotJoiltaKoskiOpiskeluoikeudetPuuttuvat.size();
         return koskiAsyncResource
-            .findKoskiOppijat(oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat)
+            .findKoskiOppijat(oppijanumerotJoiltaKoskiOpiskeluoikeudetPuuttuvat)
             .thenApplyAsync(koskioppijat -> {
                 LOG.info(String.format("Saatiin Koskesta %s uuden oppijan tiedot, kun haettiin %d/%d oppijalle (%s:lle oli jo haettu tiedot) hakukohteen %s laskemista varten.",
-                    koskioppijat.size(), oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.size(), hakemusWrappers.size(), maaraJoilleTiedotJoLoytyvat, hakukohdeOid));
+                    koskioppijat.size(), oppijanumerotJoiltaKoskiOpiskeluoikeudetPuuttuvat.size(), hakemusWrappers.size(), maaraJoilleTiedotJoLoytyvat, hakukohdeOid));
                 koskioppijat.forEach(o -> o.poistaMuuntyyppisetOpiskeluoikeudetKuin(koskenOpiskeluoikeusTyypit));
                 koskiOpiskeluoikeusHistoryService.haeVanhemmatOpiskeluoikeudetTarvittaessa(koskioppijat, paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan);
                 Map<String, KoskiOppija> koskiOppijatOppijanumeroittain = koskioppijat.stream().collect(Collectors.toMap(KoskiOppija::getOppijanumero, Function.identity()));
-                oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.forEach(oppijanumero -> {
+                oppijanumerotJoiltaKoskiOpiskeluoikeudetPuuttuvat.forEach(oppijanumero -> {
                     KoskiOppija loytynytOppija = koskiOppijatOppijanumeroittain.get(oppijanumero);
                     if (loytynytOppija != null) {
                         suoritustiedotDTO.asetaKoskiopiskeluoikeudet(oppijanumero, GSON.toJson(loytynytOppija.getOpiskeluoikeudet()));

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
@@ -1,18 +1,12 @@
 package fi.vm.sade.valinta.kooste.valintalaskenta.actor;
 
-import static fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi.ITEROIAMMATILLISETTUTKINNOT;
-import static fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi.ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI;
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 
-import fi.vm.sade.service.valintaperusteet.dto.SyoteparametriDTO;
 import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteetDTO;
 import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteetFunktiokutsuDTO;
 import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi;
 import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiOppija;
-import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiOppija.OpiskeluoikeusJsonUtil;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
 import fi.vm.sade.valintalaskenta.domain.dto.SuoritustiedotDTO;
 import org.apache.commons.lang3.StringUtils;
@@ -23,22 +17,17 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 public class KoskiService {
@@ -47,9 +36,9 @@ public class KoskiService {
     private static final Predicate<String> INCLUDE_ALL = s -> true;
     private static final Predicate<String> EXCLUDE_ALL = s -> false;
     private static final Gson GSON = new Gson();
-    private static final DateTimeFormatter FINNISH_DATE_FORMAT = DateTimeFormatter.ofPattern("d.M.yyyy");
     private final Predicate<String> koskiHakukohdeOidFilter;
     private final KoskiAsyncResource koskiAsyncResource;
+    private final KoskiOpiskeluoikeusHistoryService koskiOpiskeluoikeusHistoryService;
     private final Set<Funktionimi> koskenFunktionimet;
     private final Set<String> koskenOpiskeluoikeusTyypit;
 
@@ -62,6 +51,7 @@ public class KoskiService {
         this.koskiHakukohdeOidFilter = resolveKoskiHakukohdeOidFilter(koskiHakukohdeOiditString);
         this.koskenFunktionimet = resolveKoskenFunktionimet(koskenFunktionimetString);
         this.koskenOpiskeluoikeusTyypit = resolveKoskenOpiskeluoikeudet(koskenOpiskeluoikeusTyypitString);
+        this.koskiOpiskeluoikeusHistoryService = new KoskiOpiskeluoikeusHistoryService(koskenOpiskeluoikeusTyypit, koskiAsyncResource);
     }
 
     /**
@@ -75,7 +65,9 @@ public class KoskiService {
             return CompletableFuture.allOf(valintaperusteet, hakemukset).thenComposeAsync(x -> {
                 Collection<HakemusWrapper> hakemusWrappers = hakemukset.join();
                 if (sisaltaaKoskiFunktioita(valintaperusteet.join())) {
-                    LocalDate paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan = etsiKoskiDatanLeikkuriPvm(valintaperusteet.join(), hakukohdeOid);
+                    LocalDate paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan = koskiOpiskeluoikeusHistoryService.etsiKoskiDatanLeikkuriPvm(
+                        valintaperusteet.join(),
+                        hakukohdeOid);
                     return haeKoskiOppijat(hakukohdeOid, hakemusWrappers, suoritustiedotDTO, paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan);
                 } else {
                     LOG.info("Ei haeta tietoja Koskesta hakukohteelle " + hakukohdeOid + " , koska siltä ei löydy Koski-tietoja käyttäviä valintaperusteita.");
@@ -103,7 +95,7 @@ public class KoskiService {
             .thenApplyAsync(koskioppijat -> {
                 LOG.info(String.format("Saatiin Koskesta %s uuden oppijan tiedot, kun haettiin %d/%d oppijalle (%s:lle oli jo haettu tiedot) hakukohteen %s laskemista varten.",
                     koskioppijat.size(), oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.size(), hakemusWrappers.size(), maaraJoilleTiedotJoLoytyvat, hakukohdeOid));
-                haeUusimmatLeikkuripaivaaEdeltavatOpiskeluoikeudetTarvittaessa(koskioppijat, paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan);
+                koskiOpiskeluoikeusHistoryService.haeUusimmatLeikkuripaivaaEdeltavatOpiskeluoikeudetTarvittaessa(koskioppijat, paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan);
                 Map<String, KoskiOppija> koskiOppijatOppijanumeroittain = koskioppijat.stream().collect(Collectors.toMap(KoskiOppija::getOppijanumero, Function.identity()));
                 oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.forEach(oppijanumero -> {
                     KoskiOppija loytynytOppija = koskiOppijatOppijanumeroittain.get(oppijanumero);
@@ -135,109 +127,6 @@ public class KoskiService {
         return funktiokutsu.getFunktioargumentit().stream()
             .anyMatch(argumentti ->
                 sisaltaaKoskiFunktioita(argumentti.getFunktiokutsu()));
-    }
-
-    private LocalDate etsiKoskiDatanLeikkuriPvm(List<ValintaperusteetDTO> valintaperusteetDTOS, String hakukohdeOid) {
-        List<String> leikkuriPvmMerkkijonot = etsiTutkintojenIterointiFunktioKutsut(valintaperusteetDTOS)
-            .flatMap(tutkintojenIterointiFunktio -> tutkintojenIterointiFunktio.getSyoteparametrit().stream()
-                .filter(parametri -> ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI.equals(parametri.getAvain()) && StringUtils.isNotBlank(parametri.getArvo()))
-                .map(SyoteparametriDTO::getArvo))
-            .collect(Collectors.toList());
-        List<LocalDate> kaikkiLeikkuriPvmtValintaperusteista = leikkuriPvmMerkkijonot.stream()
-            .map(pvm -> LocalDate.parse(pvm, FINNISH_DATE_FORMAT))
-            .sorted()
-            .collect(Collectors.toList());
-        LocalDate kaytettavaLeikkuriPvm;
-        if (!kaikkiLeikkuriPvmtValintaperusteista.isEmpty()) {
-            kaytettavaLeikkuriPvm = kaikkiLeikkuriPvmtValintaperusteista.get(kaikkiLeikkuriPvmtValintaperusteista.size() - 1);
-        } else {
-            kaytettavaLeikkuriPvm = LocalDate.now();
-        }
-        LOG.info(String.format("Saatiin hakukohteen %s valintaperusteista Koski-datan leikkuripäivämäärät %s. Käytetään leikkuripäivämääränä arvoa %s.",
-            hakukohdeOid, leikkuriPvmMerkkijonot, FINNISH_DATE_FORMAT.format(kaytettavaLeikkuriPvm)));
-        return kaytettavaLeikkuriPvm;
-    }
-
-    static Stream<ValintaperusteetFunktiokutsuDTO> etsiTutkintojenIterointiFunktioKutsut(List<ValintaperusteetDTO> valintaperusteetDTOS) {
-        return valintaperusteetDTOS.stream()
-            .flatMap(valintaperusteetDTO -> valintaperusteetDTO.getValinnanVaihe().getValintatapajono().stream())
-            .flatMap(jono -> jono.getJarjestyskriteerit().stream())
-            .flatMap(kriteeri ->
-                etsiFunktiokutsutRekursiivisesti(
-                    kriteeri.getFunktiokutsu(),
-                    fk -> ITEROIAMMATILLISETTUTKINNOT.equals(fk.getFunktionimi())).stream());
-    }
-
-    static private List<ValintaperusteetFunktiokutsuDTO> etsiFunktiokutsutRekursiivisesti(ValintaperusteetFunktiokutsuDTO juuriFunktioKutsu,
-                                                                                   Predicate<ValintaperusteetFunktiokutsuDTO> predikaatti) {
-        List<ValintaperusteetFunktiokutsuDTO> tulokset = new LinkedList<>();
-        if (predikaatti.test(juuriFunktioKutsu)) {
-            tulokset.add(juuriFunktioKutsu);
-        }
-        tulokset.addAll(juuriFunktioKutsu.getFunktioargumentit().stream()
-            .flatMap(argumentti -> etsiFunktiokutsutRekursiivisesti(argumentti.getFunktiokutsu(), predikaatti).stream())
-            .collect(Collectors.toSet()));
-        return tulokset;
-    }
-
-    private void haeUusimmatLeikkuripaivaaEdeltavatOpiskeluoikeudetTarvittaessa(Set<KoskiOppija> koskioppijat, LocalDate leikkuriPvm) {
-        koskioppijat.forEach(koskiOppija -> {
-            final Set<JsonElement> liianUudetOpiskeluoikeudet = koskiOppija.opiskeluoikeudetJotkaOvatUudempiaKuin(leikkuriPvm, koskenOpiskeluoikeusTyypit);
-            if (!liianUudetOpiskeluoikeudet.isEmpty()) {
-                koskiOppija.setOpiskeluoikeudet(haeOpiskeluoikeuksistaPaivanMukainenVersio(
-                    koskiOppija,
-                    leikkuriPvm,
-                    koskiOppija.haeOpiskeluoikeudet(koskenOpiskeluoikeusTyypit)));
-            }
-        });
-    }
-
-    private JsonArray haeOpiskeluoikeuksistaPaivanMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm, JsonArray opiskeluoikeudet) {
-        JsonArray tulokset = new JsonArray();
-        opiskeluoikeudet.forEach(opiskeluoikeus -> {
-            if (OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, opiskeluoikeus)) {
-                LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
-                String opiskeluoikeudenOid = OpiskeluoikeusJsonUtil.oid(opiskeluoikeus);
-                LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s aikaleima on %s eli leikkuripäivämäärän %s jälkeen." +
-                        " Etsitään opiskeluoikeudesta versioita, jotka olisi tallennettu ennen leikkuripäivämäärää.",
-                    koskiOppija.getOppijanumero(),
-                    opiskeluoikeudenOid,
-                    aikaleima,
-                    FINNISH_DATE_FORMAT.format(leikkuriPvm)));
-                haePaivamaaranMukainenVersio(koskiOppija, leikkuriPvm, opiskeluoikeus).ifPresent(tulokset::add);
-            } else {
-                tulokset.add(opiskeluoikeus);
-            }
-        });
-        return tulokset;
-    }
-
-    private Optional<JsonElement> haePaivamaaranMukainenVersio(KoskiOppija koskiOppija, LocalDate leikkuriPvm, JsonElement opiskeluoikeus) {
-        int versionumero = OpiskeluoikeusJsonUtil.versionumero(opiskeluoikeus);
-        LocalDateTime aikaleima = OpiskeluoikeusJsonUtil.aikaleima(opiskeluoikeus);
-        String opiskeluoikeudenOid = OpiskeluoikeusJsonUtil.oid(opiskeluoikeus);
-        if (!OpiskeluoikeusJsonUtil.onUudempiKuin(leikkuriPvm, aikaleima)) {
-            LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s version %d aikaleima on %s eli ennen leikkuripäivämäärää %s, joten huomioidaan tämä opiskeluoikeus.",
-                koskiOppija.getOppijanumero(),
-                opiskeluoikeudenOid,
-                versionumero,
-                aikaleima,
-                FINNISH_DATE_FORMAT.format(leikkuriPvm)
-                ));
-            return Optional.of(opiskeluoikeus);
-        }
-        if (versionumero <= 1) {
-            LOG.info(String.format("Koskesta haetun oppijan %s opiskeluoikeuden %s aikaleima on %s eli leikkuripäivämäärän %s jälkeen," +
-                    " ja versio %d, joten vanhempia versioita ei ole. Jätetään opiskeluoikeus huomioimatta.",
-                koskiOppija.getOppijanumero(),
-                opiskeluoikeudenOid,
-                aikaleima,
-                FINNISH_DATE_FORMAT.format(leikkuriPvm),
-                versionumero));
-            return Optional.empty();
-        }
-        JsonElement edellisenVersionOpiskeluoikeus = koskiAsyncResource.findVersionOfOpiskeluoikeus(opiskeluoikeudenOid, versionumero - 1).join();
-        return haePaivamaaranMukainenVersio(koskiOppija, leikkuriPvm, edellisenVersionOpiskeluoikeus);
     }
 
     private static Predicate<String> resolveKoskiHakukohdeOidFilter(String koskiHakukohdeOiditString) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiService.java
@@ -95,12 +95,13 @@ public class KoskiService {
             .thenApplyAsync(koskioppijat -> {
                 LOG.info(String.format("Saatiin Koskesta %s uuden oppijan tiedot, kun haettiin %d/%d oppijalle (%s:lle oli jo haettu tiedot) hakukohteen %s laskemista varten.",
                     koskioppijat.size(), oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.size(), hakemusWrappers.size(), maaraJoilleTiedotJoLoytyvat, hakukohdeOid));
+                koskioppijat.forEach(o -> o.poistaMuuntyyppisetOpiskeluoikeudetKuin(koskenOpiskeluoikeusTyypit));
                 koskiOpiskeluoikeusHistoryService.haeVanhemmatOpiskeluoikeudetTarvittaessa(koskioppijat, paivaJonkaMukaisiaTietojaKoskiDatastaKaytetaan);
                 Map<String, KoskiOppija> koskiOppijatOppijanumeroittain = koskioppijat.stream().collect(Collectors.toMap(KoskiOppija::getOppijanumero, Function.identity()));
                 oppijanumeroitJoiltaKoskiOpiskeluoikeudetPuuttuvat.forEach(oppijanumero -> {
                     KoskiOppija loytynytOppija = koskiOppijatOppijanumeroittain.get(oppijanumero);
                     if (loytynytOppija != null) {
-                        suoritustiedotDTO.asetaKoskiopiskeluoikeudet(oppijanumero, GSON.toJson(loytynytOppija.haeOpiskeluoikeudet(koskenOpiskeluoikeusTyypit)));
+                        suoritustiedotDTO.asetaKoskiopiskeluoikeudet(oppijanumero, GSON.toJson(loytynytOppija.getOpiskeluoikeudet()));
                     } else {
                         suoritustiedotDTO.asetaKoskiopiskeluoikeudet(oppijanumero, "[]");
                     }

--- a/src/main/resources/oph-configuration/common.properties.template
+++ b/src/main/resources/oph-configuration/common.properties.template
@@ -79,6 +79,7 @@ valintalaskentakoostepalvelu.koski.baseurl={{valintalaskentakoostepalvelu_koski_
 valintalaskentakoostepalvelu.laskenta.koskesta.haettavat.hakukohdeoidit={{valintalaskentakoostepalvelu_laskenta_koskesta_haettavat_hakukohdeoidit | default("none")}}
 valintalaskentakoostepalvelu.laskenta.funktionimet.joille.haetaan.tiedot.koskesta={{valintalaskentakoostepalvelu_laskenta_funktionimet_joille_haetaan_tiedot_koskesta | default("HAEAMMATILLINENYTOARVOSANA,HAEAMMATILLINENYTOARVIOINTIASTEIKKO,ITEROIAMMATILLISETTUTKINNOT,ITEROIAMMATILLISETOSAT,ITEROIAMMATILLISETYTOOSAALUEET,HAEAMMATILLISENOSANLAAJUUS,HAEAMMATILLISENOSANARVOSANA,HAEAMMATILLISENYTOOSAALUEENLAAJUUS,HAEAMMATILLISENYTOOSAALUEENARVOSANA,HAEAMMATILLISENTUTKINNONKESKIARVO,HAEAMMATILLISENTUTKINNONSUORITUSTAPA")}}
 valintalaskentakoostepalvelu.laskenta.opiskeluoikeustyypit.joille.haetaan.tiedot.koskesta={{valintalaskentakoostepalvelu_laskenta_opiskeluoikeustyypit_joille_haetaan_tiedot_koskesta | default("ammatillinenkoulutus") }}
+valintalaskentakoostepalvelu.laskenta.kosken.historiapyyntojen.rinnakkaisuus={{ kosken_historiapyyntojen_rinnakkaisuus | default("10") }}
 valintalaskentakoostepalvelu.koski.username={{valintalaskentakoostepalvelu_koski_username | default("koostepalvelu2koski")}}
 valintalaskentakoostepalvelu.koski.password={{valintalaskentakoostepalvelu_koski_password}}
 valintalaskentakoostepalvelu.koski.max.oppijat.post.size={{valintalaskentakoostepalvelu_koski_max_oppijat_post_size | default("1000")}}

--- a/src/main/resources/valintalaskentakoostepalvelu-oph.properties
+++ b/src/main/resources/valintalaskentakoostepalvelu-oph.properties
@@ -140,3 +140,4 @@ valintapiste-service.get.pisteet.with.hakemusoids=${baseurl-valintapiste-service
 valintapiste-service.put.pisteet=${baseurl-valintapiste-service}/valintapiste-service/api/pisteet-with-hakemusoids
 
 koski.oppijanumeroittain.post=${baseurl-koski}/koski/api/sure/oids
+koski.opiskeluoikeuden.versio=${baseurl-koski}/koski/api/opiskeluoikeus/historia/$1/$2

--- a/src/test/java/fi/vm/sade/valinta/kooste/KoosteTestProfileConfiguration.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/KoosteTestProfileConfiguration.java
@@ -50,6 +50,7 @@ public class KoosteTestProfileConfiguration {
         p0.setProperty("valintalaskentakoostepalvelu.koski.max.oppijat.post.size", "1000");
         p0.setProperty("valintalaskentakoostepalvelu.laskenta.funktionimet.joille.haetaan.tiedot.koskesta", "HAEAMMATILLINENYTOARVOSANA,HAEAMMATILLINENYTOARVIOINTIASTEIKKO,ITEROIAMMATILLISETTUTKINNOT,ITEROIAMMATILLISETOSAT,ITEROIAMMATILLISETYTOOSAALUEET,HAEAMMATILLISENOSANLAAJUUS,HAEAMMATILLISENOSANARVOSANA,HAEAMMATILLISENYTOOSAALUEENLAAJUUS,HAEAMMATILLISENYTOOSAALUEENARVOSANA,HAEAMMATILLISENTUTKINNONKESKIARVO,HAEAMMATILLISENTUTKINNONSUORITUSTAPA");
         p0.setProperty("valintalaskentakoostepalvelu.laskenta.opiskeluoikeustyypit.joille.haetaan.tiedot.koskesta", "ammatillinenkoulutus");
+        p0.setProperty("valintalaskentakoostepalvelu.laskenta.kosken.historiapyyntojen.rinnakkaisuus", "9");
 
         p0.setProperty("valintalaskentakoostepalvelu.seuranta.rest.url", "http://localhost");
         p0.setProperty("valintalaskentakoostepalvelu.organisaatioService.rest.url", "http://" + proxyServer + "/organisaatio-service/rest");

--- a/src/test/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppijaTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/external/resource/koski/KoskiOppijaTest.java
@@ -1,0 +1,32 @@
+package fi.vm.sade.valinta.kooste.external.resource.koski;
+
+import static org.junit.Assert.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.LocalDateTime;
+
+@RunWith(JUnit4.class)
+public class KoskiOppijaTest {
+    private static final Gson GSON = new Gson();
+
+    @Test
+    public void opiskeluoikeenAikaleimassaVoiOllaEriMääräDesimaaleja() {
+        assertEquals(2018, aikaleima("{\"aikaleima\": \"2018-11-05T09:47:33.610999\"}").getYear());
+        assertEquals(33, aikaleima("{\"aikaleima\": \"2018-11-05T09:47:33.610999\"}").getSecond());
+
+        assertEquals(2018, aikaleima("{\"aikaleima\": \"2018-11-05T09:47:33.610\"}").getYear());
+        assertEquals(33, aikaleima("{\"aikaleima\": \"2018-11-05T09:47:33.610\"}").getSecond());
+
+        assertEquals(2018, aikaleima("{\"aikaleima\": \"2018-11-05T09:47:33\"}").getYear());
+        assertEquals(33, aikaleima("{\"aikaleima\": \"2018-11-05T09:47:33\"}").getSecond());
+    }
+
+    public LocalDateTime aikaleima(String opiskeluoikeusJson) {
+        return KoskiOppija.OpiskeluoikeusJsonUtil.aikaleima(GSON.fromJson(opiskeluoikeusJson, JsonElement.class));
+    }
+}

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiServiceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiServiceTest.java
@@ -148,14 +148,14 @@ public class KoskiServiceTest {
 
     private CompletableFuture<List<ValintaperusteetDTO>> koskiDataaKayttavaValintaperuste(String leikkuriPvm) {
         return this.koskiFunktionSisaltavaValintaperuste.thenApplyAsync(vps -> {
-                KoskiService.etsiTutkintojenIterointiFunktioKutsut(vps).forEach(iterointiFunktioKutsu -> {
-                    iterointiFunktioKutsu.getSyoteparametrit().stream()
-                        .filter(p -> Funktionimi.ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI.equals(p.getAvain()))
-                        .forEach(leikkuriPvmParametri ->
-                            leikkuriPvmParametri.setArvo(leikkuriPvm));
-                });
-                return vps;
+            KoskiOpiskeluoikeusHistoryService.etsiTutkintojenIterointiFunktioKutsut(vps).forEach(iterointiFunktioKutsu -> {
+                iterointiFunktioKutsu.getSyoteparametrit().stream()
+                    .filter(p -> Funktionimi.ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI.equals(p.getAvain()))
+                    .forEach(leikkuriPvmParametri ->
+                        leikkuriPvmParametri.setArvo(leikkuriPvm));
             });
+            return vps;
+        });
     }
 
     private CompletableFuture<List<ValintaperusteetDTO>> luoKoskifunktionSisaltavaValintaperuste() {

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiServiceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiServiceTest.java
@@ -60,7 +60,7 @@ public class KoskiServiceTest {
 
     @Test
     public void koskestaHaettavienHakukohteidenListallaVoiRajoittaaMilleHakukohteilleHaetaanKoskesta() throws ExecutionException, InterruptedException {
-        KoskiService service = new KoskiService("hakukohdeoid1,hakukohdeoid2", koskifuntionimet, "ammatillinenkoulutus", koskiAsyncResource);
+        KoskiService service = new KoskiService("hakukohdeoid1,hakukohdeoid2", koskifuntionimet, "ammatillinenkoulutus", 5, koskiAsyncResource);
 
         when(koskiAsyncResource.findKoskiOppijat(Collections.singletonList(oppijanumero))).thenReturn(CompletableFuture.completedFuture(koskioppijat));
 
@@ -75,7 +75,7 @@ public class KoskiServiceTest {
 
     @Test
     public void koskidataaKayttavienFunktionimienListallaVoiRajoittaaMilleHakukohteilleHaetaanKoskesta() throws ExecutionException, InterruptedException {
-        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", koskiAsyncResource);
+        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", 5, koskiAsyncResource);
 
         when(koskiAsyncResource.findKoskiOppijat(Collections.singletonList(oppijanumero))).thenReturn(CompletableFuture.completedFuture(koskioppijat));
 
@@ -90,7 +90,7 @@ public class KoskiServiceTest {
 
     @Test
     public void josOpiskeluoikeudenTiedotOnPaivitettyLeikkuriPvmJalkeenHaetaanRiittävänVanhaVersio() throws ExecutionException, InterruptedException {
-        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", koskiAsyncResource);
+        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", 5, koskiAsyncResource);
 
         when(koskiAsyncResource.findKoskiOppijat(Collections.singletonList(oppijanumero))).thenReturn(CompletableFuture.completedFuture(koskioppijat));
         when(koskiAsyncResource.findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 2))
@@ -119,7 +119,7 @@ public class KoskiServiceTest {
 
     @Test
     public void josOpiskeluoikeudenVanhinVersioOnLeikkuriPvmJalkeenJatetaanopiskeluoikeusHuomioimatta() throws ExecutionException, InterruptedException {
-        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", koskiAsyncResource);
+        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", 5, koskiAsyncResource);
 
         when(koskiAsyncResource.findKoskiOppijat(Collections.singletonList(oppijanumero))).thenReturn(CompletableFuture.completedFuture(koskioppijat));
         when(koskiAsyncResource.findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 2))

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiServiceTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskenta/actor/KoskiServiceTest.java
@@ -7,10 +7,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 
 import fi.vm.sade.service.valintaperusteet.dto.ValintaperusteetDTO;
+import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi;
 import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiAsyncResource;
 import fi.vm.sade.valinta.kooste.external.resource.koski.KoskiOppija;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
@@ -48,6 +53,9 @@ public class KoskiServiceTest {
         KoskiOppija.KoskiHenkilö koskiHenkilo = new KoskiOppija.KoskiHenkilö();
         koskiHenkilo.oid = oppijanumero;
         koskiOppija.setHenkilö(koskiHenkilo);
+        koskiOppija.setOpiskeluoikeudet(GSON.fromJson(
+            classpathResourceAsString("fi/vm/sade/valinta/kooste/valintalaskenta/koski-monitutkinto.json"),
+            JsonArray.class));
     }
 
     @Test
@@ -78,6 +86,76 @@ public class KoskiServiceTest {
         assertEquals(GSON.toJson(koskiOppija.getOpiskeluoikeudet()), suoritustiedotDTO.haeKoskiOpiskeluoikeudetJson(oppijanumero));
 
         assertThat(service.haeKoskiOppijat("hakukohdeoid1", kosketonValintaperuste, hakemukset, suoritustiedotDTO).get().entrySet(), is(empty()));
+    }
+
+    @Test
+    public void josOpiskeluoikeudenTiedotOnPaivitettyLeikkuriPvmJalkeenHaetaanRiittävänVanhaVersio() throws ExecutionException, InterruptedException {
+        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", koskiAsyncResource);
+
+        when(koskiAsyncResource.findKoskiOppijat(Collections.singletonList(oppijanumero))).thenReturn(CompletableFuture.completedFuture(koskioppijat));
+        when(koskiAsyncResource.findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 2))
+            .thenReturn(CompletableFuture.completedFuture(GSON.fromJson(
+                classpathResourceAsString("fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-05.json"),
+                JsonElement.class)));
+        when(koskiAsyncResource.findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 1))
+            .thenReturn(CompletableFuture.completedFuture(GSON.fromJson(
+                classpathResourceAsString("fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-01.json"),
+                JsonElement.class)));
+
+        CompletableFuture<List<ValintaperusteetDTO>> valintaperuste = koskiDataaKayttavaValintaperuste("1.10.2019");
+        Map<String, KoskiOppija> koskiOppijatOppijanumeroittain = service.haeKoskiOppijat("hakukohdeoid1", valintaperuste, hakemukset, suoritustiedotDTO).get();
+        assertThat(koskiOppijatOppijanumeroittain.entrySet(), hasSize(1));
+        assertEquals(koskiOppijatOppijanumeroittain.get(oppijanumero), koskiOppija);
+        assertTrue(suoritustiedotDTO.onKoskiopiskeluoikeudet(oppijanumero));
+        assertEquals(GSON.toJson(koskiOppija.getOpiskeluoikeudet()), suoritustiedotDTO.haeKoskiOpiskeluoikeudetJson(oppijanumero));
+
+        assertThat(service.haeKoskiOppijat("hakukohdeoid1", kosketonValintaperuste, hakemukset, suoritustiedotDTO).get().entrySet(), is(empty()));
+
+        verify(koskiAsyncResource).findKoskiOppijat(Collections.singletonList(oppijanumero));
+        verify(koskiAsyncResource).findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 2);
+        verify(koskiAsyncResource).findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 1);
+        verifyNoMoreInteractions(koskiAsyncResource);
+    }
+
+    @Test
+    public void josOpiskeluoikeudenVanhinVersioOnLeikkuriPvmJalkeenJatetaanopiskeluoikeusHuomioimatta() throws ExecutionException, InterruptedException {
+        KoskiService service = new KoskiService("ALL", koskifuntionimet, "ammatillinenkoulutus", koskiAsyncResource);
+
+        when(koskiAsyncResource.findKoskiOppijat(Collections.singletonList(oppijanumero))).thenReturn(CompletableFuture.completedFuture(koskioppijat));
+        when(koskiAsyncResource.findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 2))
+            .thenReturn(CompletableFuture.completedFuture(GSON.fromJson(
+                classpathResourceAsString("fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-05.json"),
+                JsonElement.class)));
+        when(koskiAsyncResource.findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 1))
+            .thenReturn(CompletableFuture.completedFuture(GSON.fromJson(
+                classpathResourceAsString("fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-01.json"),
+                JsonElement.class)));
+
+        CompletableFuture<List<ValintaperusteetDTO>> valintaperuste = koskiDataaKayttavaValintaperuste("30.9.2019");
+        Map<String, KoskiOppija> koskiOppijatOppijanumeroittain = service.haeKoskiOppijat("hakukohdeoid1", valintaperuste, hakemukset, suoritustiedotDTO).get();
+        assertThat(koskiOppijatOppijanumeroittain.entrySet(), hasSize(1));
+        assertEquals(koskiOppijatOppijanumeroittain.get(oppijanumero), koskiOppija);
+        assertTrue(suoritustiedotDTO.onKoskiopiskeluoikeudet(oppijanumero));
+        assertEquals(GSON.toJson(koskiOppija.getOpiskeluoikeudet()), suoritustiedotDTO.haeKoskiOpiskeluoikeudetJson(oppijanumero));
+
+        assertThat(service.haeKoskiOppijat("hakukohdeoid1", kosketonValintaperuste, hakemukset, suoritustiedotDTO).get().entrySet(), is(empty()));
+
+        verify(koskiAsyncResource).findKoskiOppijat(Collections.singletonList(oppijanumero));
+        verify(koskiAsyncResource).findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 2);
+        verify(koskiAsyncResource).findVersionOfOpiskeluoikeus("1.2.246.562.15.12442534343", 1);
+        verifyNoMoreInteractions(koskiAsyncResource);
+    }
+
+    private CompletableFuture<List<ValintaperusteetDTO>> koskiDataaKayttavaValintaperuste(String leikkuriPvm) {
+        return this.koskiFunktionSisaltavaValintaperuste.thenApplyAsync(vps -> {
+                KoskiService.etsiTutkintojenIterointiFunktioKutsut(vps).forEach(iterointiFunktioKutsu -> {
+                    iterointiFunktioKutsu.getSyoteparametrit().stream()
+                        .filter(p -> Funktionimi.ITEROIAMMATILLISETTUTKINNOT_LEIKKURIPVM_PARAMETRI.equals(p.getAvain()))
+                        .forEach(leikkuriPvmParametri ->
+                            leikkuriPvmParametri.setArvo(leikkuriPvm));
+                });
+                return vps;
+            });
     }
 
     private CompletableFuture<List<ValintaperusteetDTO>> luoKoskifunktionSisaltavaValintaperuste() {

--- a/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/actor/valintaperusteita_koskikaavojen_kanssa.json
+++ b/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/actor/valintaperusteita_koskikaavojen_kanssa.json
@@ -4,23 +4,37 @@
   "tarjoajaOid": "1.2.246.562.10.50880626531",
   "viimeinenValinnanvaihe": 2,
   "valinnanVaihe": {
+    "nimi": "Varsinainen valinta",
+    "kuvaus": null,
+    "aktiivinen": true,
+    "valinnanVaiheTyyppi": "TAVALLINEN",
+    "oid": null,
+    "inheritance": null,
+    "hasValisijoittelu": null,
+    "jonot": [],
     "valinnanVaiheJarjestysluku": 2,
     "valinnanVaiheOid": "1546591900204503340104920222316",
     "valintatapajono": [
       {
-        "aloituspaikat": 20,
-        "kuvaus": "Testataan VTKU-98:n Koskidatan käyttöä",
+        "aloituspaikat": 10,
+        "kuvaus": "Lasketaan ops-muotoisista (vanhanmallisista) ammatillisista perustutkinnoista pisteitä.",
         "tyyppi": "valintatapajono_tv",
-        "nimi": "Timon todistusvalinta",
-        "oid": "1573720036491299050762248760371",
+        "nimi": "Timon todistusvalinta 3.2.2020",
+        "oid": "1580741034609-465476163411125238",
         "prioriteetti": 1,
         "siirretaanSijoitteluun": true,
         "tasasijasaanto": "YLITAYTTO",
+        "eiLasketaPaivamaaranJalkeen": null,
         "jarjestyskriteerit": [
           {
+            "nimi": "Ammatillisen perustutkinnon pisteet",
             "prioriteetti": 0,
             "funktiokutsu": {
               "funktionimi": "NIMETTYLUKUARVO",
+              "tulosTunniste": null,
+              "tulosTekstiFi": null,
+              "tulosTekstiSv": null,
+              "tulosTekstiEn": null,
               "tallennaTulos": false,
               "omaopintopolku": false,
               "arvokonvertteriparametrit": [],
@@ -28,47 +42,6407 @@
               "syoteparametrit": [
                 {
                   "avain": "nimi",
-                  "arvo": "ammatillinen_VTKU-98_20191114"
+                  "arvo": "Ammatillisen perustutkinnon pisteet"
                 }
               ],
               "funktioargumentit": [
                 {
                   "funktiokutsu": {
-                    "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
-                    "tulosTunniste": "amm_yto_ml",
-                    "tulosTekstiFi": "Ammatillisen perustutkinnon yto Matemaattis-luonnontieteellinen osaaminen",
-                    "tulosTekstiSv": "Ammatillisen perustutkinnon yto Matemaattis-luonnontieteellinen osaaminen",
-                    "tulosTekstiEn": "Ammatillisen perustutkinnon yto Matemaattis-luonnontieteellinen osaaminen",
+                    "funktionimi": "ITEROIAMMATILLISETTUTKINNOT",
+                    "tulosTunniste": "iteroi_amm_perustutkinnot",
+                    "tulosTekstiFi": "Iteroi ammatilliset perustutkinnot",
+                    "tulosTekstiSv": "Iteroi ammatilliset perustutkinnot (sv)",
+                    "tulosTekstiEn": "Iteroi ammatilliset perustutkinnot (en)",
                     "tallennaTulos": true,
-                    "omaopintopolku": true,
+                    "omaopintopolku": false,
                     "arvokonvertteriparametrit": [],
                     "arvovalikonvertteriparametrit": [],
-                    "syoteparametrit": [],
-                    "funktioargumentit": [],
-                    "valintaperusteviitteet": [
+                    "syoteparametrit": [
                       {
-                        "tunniste": "101054",
-                        "kuvaus": "Ammatillisen perustutkinnon yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arvosana.",
-                        "lahde": "HAETTAVA_ARVO",
-                        "onPakollinen": false,
-                        "epasuoraViittaus": false,
-                        "indeksi": 2,
-                        "vaatiiOsallistumisen": true,
-                        "syotettavissaKaikille": true,
-                        "kuvaukset": {
-                          "tekstit": []
-                        },
-                        "tilastoidaan": false
+                        "avain": "valmistumisenTakarajaPvm",
+                        "arvo": "1.1.2020"
+                      },
+                      {
+                        "avain": "koskessaViimeistaanPvm",
+                        "arvo": "15.2.2020"
                       }
                     ],
-                    "id": 481912247
+                    "funktioargumentit": [
+                      {
+                        "funktiokutsu": {
+                          "funktionimi": "MAKSIMI",
+                          "tulosTunniste": "paras_amm_perustutkinto",
+                          "tulosTekstiFi": "Maksimi ammatillisten perustutkintojen antamista pisteistä",
+                          "tulosTekstiSv": "Maksimi ammatillisten perustutkintojen antamista pisteistä (sv)",
+                          "tulosTekstiEn": "Maksimi ammatillisten perustutkintojen antamista pisteistä (en)",
+                          "tallennaTulos": true,
+                          "omaopintopolku": false,
+                          "arvokonvertteriparametrit": [],
+                          "arvovalikonvertteriparametrit": [],
+                          "syoteparametrit": [],
+                          "funktioargumentit": [
+                            {
+                              "funktiokutsu": {
+                                "funktionimi": "JOS",
+                                "tulosTunniste": null,
+                                "tulosTekstiFi": null,
+                                "tulosTekstiSv": null,
+                                "tulosTekstiEn": null,
+                                "tallennaTulos": false,
+                                "omaopintopolku": false,
+                                "arvokonvertteriparametrit": [],
+                                "arvovalikonvertteriparametrit": [],
+                                "syoteparametrit": [],
+                                "funktioargumentit": [
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "JOS",
+                                      "tulosTunniste": null,
+                                      "tulosTekstiFi": null,
+                                      "tulosTekstiSv": null,
+                                      "tulosTekstiEn": null,
+                                      "tallennaTulos": false,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [],
+                                      "funktioargumentit": [
+                                        {
+                                          "funktiokutsu": {
+                                            "funktionimi": "NIMETTYLUKUARVO",
+                                            "tulosTunniste": null,
+                                            "tulosTekstiFi": null,
+                                            "tulosTekstiSv": null,
+                                            "tulosTekstiEn": null,
+                                            "tallennaTulos": false,
+                                            "omaopintopolku": false,
+                                            "arvokonvertteriparametrit": [],
+                                            "arvovalikonvertteriparametrit": [],
+                                            "syoteparametrit": [
+                                              {
+                                                "avain": "nimi",
+                                                "arvo": "Reformi-mallisen ammatillisen perustutkinnon pisteet"
+                                              }
+                                            ],
+                                            "funktioargumentit": [
+                                              {
+                                                "funktiokutsu": {
+                                                  "funktionimi": "SUMMA",
+                                                  "tulosTunniste": "amm_perustutkinto_reformi_pisteet",
+                                                  "tulosTekstiFi": "Pisteet reformin mukaisesta ammatillisesta perustutkinnosta",
+                                                  "tulosTekstiSv": "Pisteet reformin mukaisesta ammatillisesta perustutkinnosta (sv)",
+                                                  "tulosTekstiEn": "Pisteet reformin mukaisesta ammatillisesta perustutkinnosta (en)",
+                                                  "tallennaTulos": true,
+                                                  "omaopintopolku": true,
+                                                  "arvokonvertteriparametrit": [],
+                                                  "arvovalikonvertteriparametrit": [],
+                                                  "syoteparametrit": [],
+                                                  "funktioargumentit": [
+                                                    {
+                                                      "funktiokutsu": {
+                                                        "funktionimi": "KONVERTOILUKUARVO",
+                                                        "tulosTunniste": "amm_reformi_keskiarvon_pisteet",
+                                                        "tulosTekstiFi": "Pisteet reformi-mallisen tutkinnon keskiarvosta",
+                                                        "tulosTekstiSv": "Pisteet reformi-mallisen tutkinnon keskiarvosta (sv)",
+                                                        "tulosTekstiEn": "Pisteet reformi-mallisen tutkinnon keskiarvosta (en)",
+                                                        "tallennaTulos": true,
+                                                        "omaopintopolku": true,
+                                                        "arvokonvertteriparametrit": [],
+                                                        "arvovalikonvertteriparametrit": [
+                                                          {
+                                                            "paluuarvo": "74",
+                                                            "minValue": "4.52",
+                                                            "maxValue": "4.55",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "30",
+                                                            "minValue": "2.80",
+                                                            "maxValue": "2.85",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "2",
+                                                            "minValue": "1.17",
+                                                            "maxValue": "1.23",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "32",
+                                                            "minValue": "2.89",
+                                                            "maxValue": "2.93",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "86",
+                                                            "minValue": "4.88",
+                                                            "maxValue": "4.91",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "56",
+                                                            "minValue": "3.87",
+                                                            "maxValue": "3.91",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "85",
+                                                            "minValue": "4.85",
+                                                            "maxValue": "4.88",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "28",
+                                                            "minValue": "2.71",
+                                                            "maxValue": "2.76",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "63",
+                                                            "minValue": "4.13",
+                                                            "maxValue": "4.16",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "82",
+                                                            "minValue": "4.76",
+                                                            "maxValue": "4.79",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "45",
+                                                            "minValue": "3.46",
+                                                            "maxValue": "3.50",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "17",
+                                                            "minValue": "2.12",
+                                                            "maxValue": "2.18",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "81",
+                                                            "minValue": "4.73",
+                                                            "maxValue": "4.76",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "71",
+                                                            "minValue": "4.42",
+                                                            "maxValue": "4.46",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "64",
+                                                            "minValue": "4.16",
+                                                            "maxValue": "4.20",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "36",
+                                                            "minValue": "3.07",
+                                                            "maxValue": "3.11",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "24",
+                                                            "minValue": "2.54",
+                                                            "maxValue": "2.58",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "87",
+                                                            "minValue": "4.91",
+                                                            "maxValue": "4.94",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "15",
+                                                            "minValue": "1.99",
+                                                            "maxValue": "2.05",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "42",
+                                                            "minValue": "3.33",
+                                                            "maxValue": "3.37",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "66",
+                                                            "minValue": "4.24",
+                                                            "maxValue": "4.28",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "60",
+                                                            "minValue": "4.02",
+                                                            "maxValue": "4.05",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "0",
+                                                            "minValue": "1",
+                                                            "maxValue": "1.11",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "41",
+                                                            "minValue": "3.29",
+                                                            "maxValue": "3.33",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "27",
+                                                            "minValue": "2.67",
+                                                            "maxValue": "2.71",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "23",
+                                                            "minValue": "2.49",
+                                                            "maxValue": "2.54",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "80",
+                                                            "minValue": "4.70",
+                                                            "maxValue": "4.73",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "72",
+                                                            "minValue": "4.46",
+                                                            "maxValue": "4.49",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "4",
+                                                            "minValue": "1.30",
+                                                            "maxValue": "1.36",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "61",
+                                                            "minValue": "4.05",
+                                                            "maxValue": "4.09",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "18",
+                                                            "minValue": "2.18",
+                                                            "maxValue": "2.24",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "44",
+                                                            "minValue": "3.42",
+                                                            "maxValue": "3.46",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "52",
+                                                            "minValue": "3.72",
+                                                            "maxValue": "3.76",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "53",
+                                                            "minValue": "3.76",
+                                                            "maxValue": "3.79",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "59",
+                                                            "minValue": "3.98",
+                                                            "maxValue": "4.02",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "20",
+                                                            "minValue": "2.30",
+                                                            "maxValue": "2.37",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "50",
+                                                            "minValue": "3.65",
+                                                            "maxValue": "3.68",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "7",
+                                                            "minValue": "1.49",
+                                                            "maxValue": "1.55",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "55",
+                                                            "minValue": "3.83",
+                                                            "maxValue": "3.87",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "84",
+                                                            "minValue": "4.82",
+                                                            "maxValue": "4.85",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "77",
+                                                            "minValue": "4.61",
+                                                            "maxValue": "4.64",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "70",
+                                                            "minValue": "4.39",
+                                                            "maxValue": "4.42",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "22",
+                                                            "minValue": "2.43",
+                                                            "maxValue": "2.49",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "10",
+                                                            "minValue": "1.67",
+                                                            "maxValue": "1.74",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "48",
+                                                            "minValue": "3.57",
+                                                            "maxValue": "3.61",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "12",
+                                                            "minValue": "1.80",
+                                                            "maxValue": "1.86",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "25",
+                                                            "minValue": "2.58",
+                                                            "maxValue": "2.63",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "1",
+                                                            "minValue": "1.11",
+                                                            "maxValue": "1.17",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "11",
+                                                            "minValue": "1.74",
+                                                            "maxValue": "1.80",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "68",
+                                                            "minValue": "4.31",
+                                                            "maxValue": "4.35",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "90",
+                                                            "minValue": "5",
+                                                            "maxValue": "5.1",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "19",
+                                                            "minValue": "2.24",
+                                                            "maxValue": "2.30",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "26",
+                                                            "minValue": "2.63",
+                                                            "maxValue": "2.67",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "54",
+                                                            "minValue": "3.79",
+                                                            "maxValue": "3.83",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "13",
+                                                            "minValue": "1.86",
+                                                            "maxValue": "1.93",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "49",
+                                                            "minValue": "3.61",
+                                                            "maxValue": "3.65",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "78",
+                                                            "minValue": "4.64",
+                                                            "maxValue": "4.67",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "6",
+                                                            "minValue": "1.42",
+                                                            "maxValue": "1.49",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "58",
+                                                            "minValue": "3.94",
+                                                            "maxValue": "3.98",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "37",
+                                                            "minValue": "3.11",
+                                                            "maxValue": "3.15",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "38",
+                                                            "minValue": "3.15",
+                                                            "maxValue": "3.20",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "83",
+                                                            "minValue": "4.79",
+                                                            "maxValue": "4.82",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "39",
+                                                            "minValue": "3.20",
+                                                            "maxValue": "3.24",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "40",
+                                                            "minValue": "3.24",
+                                                            "maxValue": "3.29",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "88",
+                                                            "minValue": "4.94",
+                                                            "maxValue": "4.97",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "5",
+                                                            "minValue": "1.36",
+                                                            "maxValue": "1.42",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "9",
+                                                            "minValue": "1.61",
+                                                            "maxValue": "1.67",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "0",
+                                                            "minValue": "0",
+                                                            "maxValue": "1",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "21",
+                                                            "minValue": "2.37",
+                                                            "maxValue": "2.43",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "65",
+                                                            "minValue": "4.20",
+                                                            "maxValue": "4.24",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "73",
+                                                            "minValue": "4.49",
+                                                            "maxValue": "4.52",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "3",
+                                                            "minValue": "1.23",
+                                                            "maxValue": "1.30",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "14",
+                                                            "minValue": "1.93",
+                                                            "maxValue": "1.99",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "33",
+                                                            "minValue": "2.93",
+                                                            "maxValue": "2.98",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "79",
+                                                            "minValue": "4.67",
+                                                            "maxValue": "4.70",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "89",
+                                                            "minValue": "4.97",
+                                                            "maxValue": "5",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "69",
+                                                            "minValue": "4.35",
+                                                            "maxValue": "4.39",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "47",
+                                                            "minValue": "3.54",
+                                                            "maxValue": "3.57",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "46",
+                                                            "minValue": "3.50",
+                                                            "maxValue": "3.54",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "29",
+                                                            "minValue": "2.76",
+                                                            "maxValue": "2.80",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "51",
+                                                            "minValue": "3.68",
+                                                            "maxValue": "3.72",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "35",
+                                                            "minValue": "3.02",
+                                                            "maxValue": "3.07",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "16",
+                                                            "minValue": "2.05",
+                                                            "maxValue": "2.12",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "57",
+                                                            "minValue": "3.91",
+                                                            "maxValue": "3.94",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "8",
+                                                            "minValue": "1.55",
+                                                            "maxValue": "1.61",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "34",
+                                                            "minValue": "2.98",
+                                                            "maxValue": "3.02",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "75",
+                                                            "minValue": "4.55",
+                                                            "maxValue": "4.58",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "76",
+                                                            "minValue": "4.58",
+                                                            "maxValue": "4.61",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "67",
+                                                            "minValue": "4.28",
+                                                            "maxValue": "4.31",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "62",
+                                                            "minValue": "4.09",
+                                                            "maxValue": "4.13",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "43",
+                                                            "minValue": "3.37",
+                                                            "maxValue": "3.42",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "31",
+                                                            "minValue": "2.85",
+                                                            "maxValue": "2.89",
+                                                            "palautaHaettuArvo": "false",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          }
+                                                        ],
+                                                        "syoteparametrit": [],
+                                                        "funktioargumentit": [
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "HAEAMMATILLISENTUTKINNONKESKIARVO",
+                                                              "tulosTunniste": "amm_tutkinnon_tallennettu_keskiarvo",
+                                                              "tulosTekstiFi": "Ammatillisen tutkinnon tallennettu keskiarvo",
+                                                              "tulosTekstiSv": "Ammatillisen tutkinnon tallennettu keskiarvo (sv)",
+                                                              "tulosTekstiEn": "Ammatillisen tutkinnon tallennettu keskiarvo (en)",
+                                                              "tallennaTulos": true,
+                                                              "omaopintopolku": true,
+                                                              "arvokonvertteriparametrit": [],
+                                                              "arvovalikonvertteriparametrit": [],
+                                                              "syoteparametrit": [],
+                                                              "funktioargumentit": [],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 559706160
+                                                            },
+                                                            "indeksi": 1,
+                                                            "id": 559706346
+                                                          }
+                                                        ],
+                                                        "valintaperusteviitteet": [],
+                                                        "id": 559706253
+                                                      },
+                                                      "indeksi": 2,
+                                                      "id": 559706349
+                                                    },
+                                                    {
+                                                      "funktiokutsu": {
+                                                        "funktionimi": "LUKUARVO",
+                                                        "tulosTunniste": null,
+                                                        "tulosTekstiFi": null,
+                                                        "tulosTekstiSv": null,
+                                                        "tulosTekstiEn": null,
+                                                        "tallennaTulos": false,
+                                                        "omaopintopolku": false,
+                                                        "arvokonvertteriparametrit": [],
+                                                        "arvovalikonvertteriparametrit": [],
+                                                        "syoteparametrit": [
+                                                          {
+                                                            "avain": "luku",
+                                                            "arvo": "0"
+                                                          }
+                                                        ],
+                                                        "funktioargumentit": [],
+                                                        "valintaperusteviitteet": [],
+                                                        "id": 559706158
+                                                      },
+                                                      "indeksi": 1,
+                                                      "id": 559706348
+                                                    },
+                                                    {
+                                                      "funktiokutsu": {
+                                                        "funktionimi": "NIMETTYLUKUARVO",
+                                                        "tulosTunniste": null,
+                                                        "tulosTekstiFi": null,
+                                                        "tulosTekstiSv": null,
+                                                        "tulosTekstiEn": null,
+                                                        "tallennaTulos": false,
+                                                        "omaopintopolku": false,
+                                                        "arvokonvertteriparametrit": [],
+                                                        "arvovalikonvertteriparametrit": [],
+                                                        "syoteparametrit": [
+                                                          {
+                                                            "avain": "nimi",
+                                                            "arvo": "Reformi-YTOjen pisteet"
+                                                          }
+                                                        ],
+                                                        "funktioargumentit": [
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "SUMMA",
+                                                              "tulosTunniste": "amm_ytojen_pisteet",
+                                                              "tulosTekstiFi": "Pisteet ammatillisista YTOista",
+                                                              "tulosTekstiSv": "Pisteet ammatillisista YTOista (sv)",
+                                                              "tulosTekstiEn": "Pisteet ammatillisista YTOista (en)",
+                                                              "tallennaTulos": true,
+                                                              "omaopintopolku": true,
+                                                              "arvokonvertteriparametrit": [],
+                                                              "arvovalikonvertteriparametrit": [],
+                                                              "syoteparametrit": [],
+                                                              "funktioargumentit": [
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "ITEROIAMMATILLISETYTOOSAALUEET",
+                                                                    "tulosTunniste": null,
+                                                                    "tulosTekstiFi": null,
+                                                                    "tulosTekstiSv": null,
+                                                                    "tulosTekstiEn": null,
+                                                                    "tallennaTulos": false,
+                                                                    "omaopintopolku": false,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [],
+                                                                    "funktioargumentit": [
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "NIMETTYLUKUARVO",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [
+                                                                            {
+                                                                              "avain": "nimi",
+                                                                              "arvo": "Reformi-YTOn pisteet"
+                                                                            }
+                                                                          ],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "KONVERTOILUKUARVO",
+                                                                                "tulosTunniste": "amm_yton_reformin_pisteet",
+                                                                                "tulosTekstiFi": "Amm YTOn pisteet keskiarvosta (reformi)",
+                                                                                "tulosTekstiSv": "Amm YTOn pisteet keskiarvosta (reformi) (sv)",
+                                                                                "tulosTekstiEn": "Amm YTOn pisteet keskiarvosta (reformi) (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": true,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "1",
+                                                                                    "minValue": "1",
+                                                                                    "maxValue": "2",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "5",
+                                                                                    "minValue": "2",
+                                                                                    "maxValue": "3",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "15",
+                                                                                    "minValue": "4",
+                                                                                    "maxValue": "5",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "0",
+                                                                                    "minValue": "0",
+                                                                                    "maxValue": "1",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "10",
+                                                                                    "minValue": "3",
+                                                                                    "maxValue": "4",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "minValue": "5",
+                                                                                    "maxValue": "5.1",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "PAINOTETTUKESKIARVO",
+                                                                                      "tulosTunniste": "amm_yton_painotettu_keskiarvo",
+                                                                                      "tulosTekstiFi": "YTOn painotettu keskiarvo",
+                                                                                      "tulosTekstiSv": "YTOn painotettu keskiarvo (sv)",
+                                                                                      "tulosTekstiEn": "YTOn painotettu keskiarvo (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": true,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen YTOn osa-alueen laajuus"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLISENYTOOSAALUEENLAAJUUS",
+                                                                                                  "tulosTunniste": "amm_yton_osa_alueen_laajuus",
+                                                                                                  "tulosTekstiFi": "Ammatilisen YTOn osa-alueen laajuus",
+                                                                                                  "tulosTekstiSv": "Ammatilisen YTOn osa-alueen laajuus (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatilisen YTOn osa-alueen laajuus (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [],
+                                                                                                  "id": 558894863
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558894865
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558894864
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558895489
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen YTOn osa-alueen arvosana"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLISENYTOOSAALUEENARVOSANA",
+                                                                                                  "tulosTunniste": "amm_yton_osa_alueen_arvosana",
+                                                                                                  "tulosTekstiFi": "Ammatillisen YTOn osa-alueen arvosana",
+                                                                                                  "tulosTekstiSv": "Ammatillisen YTOn osa-alueen arvosana (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen YTOn osa-alueen arvosana (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [],
+                                                                                                  "id": 558895484
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558895486
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558895485
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558895490
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558895488
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558895504
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558895497
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558895506
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558895505
+                                                                        },
+                                                                        "indeksi": 1,
+                                                                        "id": 558895826
+                                                                      }
+                                                                    ],
+                                                                    "valintaperusteviitteet": [
+                                                                      {
+                                                                        "tunniste": "400012",
+                                                                        "kuvaus": "Amm YTOn Viestintä 400012 iterointi",
+                                                                        "lahde": "HAETTAVA_ARVO",
+                                                                        "onPakollinen": false,
+                                                                        "epasuoraViittaus": false,
+                                                                        "indeksi": 2,
+                                                                        "vaatiiOsallistumisen": true,
+                                                                        "syotettavissaKaikille": true,
+                                                                        "kuvaukset": {
+                                                                          "tekstit": []
+                                                                        },
+                                                                        "syotettavanarvontyyppi": null,
+                                                                        "tilastoidaan": false
+                                                                      }
+                                                                    ],
+                                                                    "id": 558895825
+                                                                  },
+                                                                  "indeksi": 2,
+                                                                  "id": 558895838
+                                                                },
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "LUKUARVO",
+                                                                    "tulosTunniste": null,
+                                                                    "tulosTekstiFi": null,
+                                                                    "tulosTekstiSv": null,
+                                                                    "tulosTekstiEn": null,
+                                                                    "tallennaTulos": false,
+                                                                    "omaopintopolku": false,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [
+                                                                      {
+                                                                        "avain": "luku",
+                                                                        "arvo": "0"
+                                                                      }
+                                                                    ],
+                                                                    "funktioargumentit": [],
+                                                                    "valintaperusteviitteet": [],
+                                                                    "id": 558895822
+                                                                  },
+                                                                  "indeksi": 1,
+                                                                  "id": 558895837
+                                                                },
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "ITEROIAMMATILLISETYTOOSAALUEET",
+                                                                    "tulosTunniste": null,
+                                                                    "tulosTekstiFi": null,
+                                                                    "tulosTekstiSv": null,
+                                                                    "tulosTekstiEn": null,
+                                                                    "tallennaTulos": false,
+                                                                    "omaopintopolku": false,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [],
+                                                                    "funktioargumentit": [
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "NIMETTYLUKUARVO",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [
+                                                                            {
+                                                                              "avain": "nimi",
+                                                                              "arvo": "Reformi-YTOn pisteet"
+                                                                            }
+                                                                          ],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "KONVERTOILUKUARVO",
+                                                                                "tulosTunniste": "amm_yton_reformin_pisteet",
+                                                                                "tulosTekstiFi": "Amm YTOn pisteet keskiarvosta (reformi)",
+                                                                                "tulosTekstiSv": "Amm YTOn pisteet keskiarvosta (reformi) (sv)",
+                                                                                "tulosTekstiEn": "Amm YTOn pisteet keskiarvosta (reformi) (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": true,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "1",
+                                                                                    "minValue": "1",
+                                                                                    "maxValue": "2",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "10",
+                                                                                    "minValue": "3",
+                                                                                    "maxValue": "4",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "minValue": "5",
+                                                                                    "maxValue": "5.1",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "15",
+                                                                                    "minValue": "4",
+                                                                                    "maxValue": "5",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "0",
+                                                                                    "minValue": "0",
+                                                                                    "maxValue": "1",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "5",
+                                                                                    "minValue": "2",
+                                                                                    "maxValue": "3",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "PAINOTETTUKESKIARVO",
+                                                                                      "tulosTunniste": "amm_yton_painotettu_keskiarvo",
+                                                                                      "tulosTekstiFi": "YTOn painotettu keskiarvo",
+                                                                                      "tulosTekstiSv": "YTOn painotettu keskiarvo (sv)",
+                                                                                      "tulosTekstiEn": "YTOn painotettu keskiarvo (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": true,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen YTOn osa-alueen arvosana"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLISENYTOOSAALUEENARVOSANA",
+                                                                                                  "tulosTunniste": "amm_yton_osa_alueen_arvosana",
+                                                                                                  "tulosTekstiFi": "Ammatillisen YTOn osa-alueen arvosana",
+                                                                                                  "tulosTekstiSv": "Ammatillisen YTOn osa-alueen arvosana (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen YTOn osa-alueen arvosana (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [],
+                                                                                                  "id": 558895484
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558895486
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558895485
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558895490
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen YTOn osa-alueen laajuus"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLISENYTOOSAALUEENLAAJUUS",
+                                                                                                  "tulosTunniste": "amm_yton_osa_alueen_laajuus",
+                                                                                                  "tulosTekstiFi": "Ammatilisen YTOn osa-alueen laajuus",
+                                                                                                  "tulosTekstiSv": "Ammatilisen YTOn osa-alueen laajuus (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatilisen YTOn osa-alueen laajuus (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [],
+                                                                                                  "id": 558894863
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558894865
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558894864
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558895489
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558895488
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558895504
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558895497
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558895506
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558895505
+                                                                        },
+                                                                        "indeksi": 1,
+                                                                        "id": 558895830
+                                                                      }
+                                                                    ],
+                                                                    "valintaperusteviitteet": [
+                                                                      {
+                                                                        "tunniste": "400013",
+                                                                        "kuvaus": "Amm YTOn Matlu 400013 iterointi",
+                                                                        "lahde": "HAETTAVA_ARVO",
+                                                                        "onPakollinen": false,
+                                                                        "epasuoraViittaus": false,
+                                                                        "indeksi": 2,
+                                                                        "vaatiiOsallistumisen": true,
+                                                                        "syotettavissaKaikille": true,
+                                                                        "kuvaukset": {
+                                                                          "tekstit": []
+                                                                        },
+                                                                        "syotettavanarvontyyppi": null,
+                                                                        "tilastoidaan": false
+                                                                      }
+                                                                    ],
+                                                                    "id": 558895829
+                                                                  },
+                                                                  "indeksi": 3,
+                                                                  "id": 558895839
+                                                                },
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "ITEROIAMMATILLISETYTOOSAALUEET",
+                                                                    "tulosTunniste": null,
+                                                                    "tulosTekstiFi": null,
+                                                                    "tulosTekstiSv": null,
+                                                                    "tulosTekstiEn": null,
+                                                                    "tallennaTulos": false,
+                                                                    "omaopintopolku": false,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [],
+                                                                    "funktioargumentit": [
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "NIMETTYLUKUARVO",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [
+                                                                            {
+                                                                              "avain": "nimi",
+                                                                              "arvo": "Reformi-YTOn pisteet"
+                                                                            }
+                                                                          ],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "KONVERTOILUKUARVO",
+                                                                                "tulosTunniste": "amm_yton_reformin_pisteet",
+                                                                                "tulosTekstiFi": "Amm YTOn pisteet keskiarvosta (reformi)",
+                                                                                "tulosTekstiSv": "Amm YTOn pisteet keskiarvosta (reformi) (sv)",
+                                                                                "tulosTekstiEn": "Amm YTOn pisteet keskiarvosta (reformi) (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": true,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "5",
+                                                                                    "minValue": "2",
+                                                                                    "maxValue": "3",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "15",
+                                                                                    "minValue": "4",
+                                                                                    "maxValue": "5",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "10",
+                                                                                    "minValue": "3",
+                                                                                    "maxValue": "4",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "0",
+                                                                                    "minValue": "0",
+                                                                                    "maxValue": "1",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "1",
+                                                                                    "minValue": "1",
+                                                                                    "maxValue": "2",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "minValue": "5",
+                                                                                    "maxValue": "5.1",
+                                                                                    "palautaHaettuArvo": "false",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "PAINOTETTUKESKIARVO",
+                                                                                      "tulosTunniste": "amm_yton_painotettu_keskiarvo",
+                                                                                      "tulosTekstiFi": "YTOn painotettu keskiarvo",
+                                                                                      "tulosTekstiSv": "YTOn painotettu keskiarvo (sv)",
+                                                                                      "tulosTekstiEn": "YTOn painotettu keskiarvo (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": true,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen YTOn osa-alueen laajuus"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLISENYTOOSAALUEENLAAJUUS",
+                                                                                                  "tulosTunniste": "amm_yton_osa_alueen_laajuus",
+                                                                                                  "tulosTekstiFi": "Ammatilisen YTOn osa-alueen laajuus",
+                                                                                                  "tulosTekstiSv": "Ammatilisen YTOn osa-alueen laajuus (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatilisen YTOn osa-alueen laajuus (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [],
+                                                                                                  "id": 558894863
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558894865
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558894864
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558895489
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen YTOn osa-alueen arvosana"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLISENYTOOSAALUEENARVOSANA",
+                                                                                                  "tulosTunniste": "amm_yton_osa_alueen_arvosana",
+                                                                                                  "tulosTekstiFi": "Ammatillisen YTOn osa-alueen arvosana",
+                                                                                                  "tulosTekstiSv": "Ammatillisen YTOn osa-alueen arvosana (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen YTOn osa-alueen arvosana (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [],
+                                                                                                  "id": 558895484
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558895486
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558895485
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558895490
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558895488
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558895504
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558895497
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558895506
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558895505
+                                                                        },
+                                                                        "indeksi": 1,
+                                                                        "id": 558895834
+                                                                      }
+                                                                    ],
+                                                                    "valintaperusteviitteet": [
+                                                                      {
+                                                                        "tunniste": "400014",
+                                                                        "kuvaus": "Amm YTO Yhteiskunta 400014 iterointi",
+                                                                        "lahde": "HAETTAVA_ARVO",
+                                                                        "onPakollinen": false,
+                                                                        "epasuoraViittaus": false,
+                                                                        "indeksi": 2,
+                                                                        "vaatiiOsallistumisen": true,
+                                                                        "syotettavissaKaikille": true,
+                                                                        "kuvaukset": {
+                                                                          "tekstit": []
+                                                                        },
+                                                                        "syotettavanarvontyyppi": null,
+                                                                        "tilastoidaan": false
+                                                                      }
+                                                                    ],
+                                                                    "id": 558895833
+                                                                  },
+                                                                  "indeksi": 4,
+                                                                  "id": 558895840
+                                                                }
+                                                              ],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 558895836
+                                                            },
+                                                            "indeksi": 1,
+                                                            "id": 558895842
+                                                          }
+                                                        ],
+                                                        "valintaperusteviitteet": [],
+                                                        "id": 558895841
+                                                      },
+                                                      "indeksi": 3,
+                                                      "id": 559706350
+                                                    }
+                                                  ],
+                                                  "valintaperusteviitteet": [],
+                                                  "id": 559706347
+                                                },
+                                                "indeksi": 1,
+                                                "id": 559706352
+                                              }
+                                            ],
+                                            "valintaperusteviitteet": [],
+                                            "id": 559706351
+                                          },
+                                          "indeksi": 2,
+                                          "id": 560515999
+                                        },
+                                        {
+                                          "funktiokutsu": {
+                                            "funktionimi": "LUKUARVO",
+                                            "tulosTunniste": null,
+                                            "tulosTekstiFi": null,
+                                            "tulosTekstiSv": null,
+                                            "tulosTekstiEn": null,
+                                            "tallennaTulos": false,
+                                            "omaopintopolku": false,
+                                            "arvokonvertteriparametrit": [],
+                                            "arvovalikonvertteriparametrit": [],
+                                            "syoteparametrit": [
+                                              {
+                                                "avain": "luku",
+                                                "arvo": "0"
+                                              }
+                                            ],
+                                            "funktioargumentit": [],
+                                            "valintaperusteviitteet": [],
+                                            "id": 560515995
+                                          },
+                                          "indeksi": 3,
+                                          "id": 560516000
+                                        },
+                                        {
+                                          "funktiokutsu": {
+                                            "funktionimi": "YHTASUURI",
+                                            "tulosTunniste": null,
+                                            "tulosTekstiFi": null,
+                                            "tulosTekstiSv": null,
+                                            "tulosTekstiEn": null,
+                                            "tallennaTulos": false,
+                                            "omaopintopolku": false,
+                                            "arvokonvertteriparametrit": [],
+                                            "arvovalikonvertteriparametrit": [],
+                                            "syoteparametrit": [],
+                                            "funktioargumentit": [
+                                              {
+                                                "funktiokutsu": {
+                                                  "funktionimi": "NIMETTYLUKUARVO",
+                                                  "tulosTunniste": null,
+                                                  "tulosTekstiFi": null,
+                                                  "tulosTekstiSv": null,
+                                                  "tulosTekstiEn": null,
+                                                  "tallennaTulos": false,
+                                                  "omaopintopolku": false,
+                                                  "arvokonvertteriparametrit": [],
+                                                  "arvovalikonvertteriparametrit": [],
+                                                  "syoteparametrit": [
+                                                    {
+                                                      "avain": "nimi",
+                                                      "arvo": "Ammatillisen perustutkinnon suoritustapa"
+                                                    }
+                                                  ],
+                                                  "funktioargumentit": [
+                                                    {
+                                                      "funktiokutsu": {
+                                                        "funktionimi": "NIMETTYLUKUARVO",
+                                                        "tulosTunniste": "amm_tutkinnon_suoritustapa",
+                                                        "tulosTekstiFi": "Ammatillisen perustutkinnon suoritustapa",
+                                                        "tulosTekstiSv": "Ammatillisen perustutkinnon suoritustapa (sv)",
+                                                        "tulosTekstiEn": "Ammatillisen perustutkinnon suoritustapa (en)",
+                                                        "tallennaTulos": true,
+                                                        "omaopintopolku": true,
+                                                        "arvokonvertteriparametrit": [],
+                                                        "arvovalikonvertteriparametrit": [],
+                                                        "syoteparametrit": [
+                                                          {
+                                                            "avain": "nimi",
+                                                            "arvo": "Ammatillisen perustutkinnon suoritustapa"
+                                                          }
+                                                        ],
+                                                        "funktioargumentit": [
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "HAEAMMATILLISENTUTKINNONSUORITUSTAPA",
+                                                              "tulosTunniste": "amm_tutkinnon_suoritustapa",
+                                                              "tulosTekstiFi": "Ammatillisen perustutkinnon suoritustapa (ops / reformi) lukuarvoksi (2015 / 2017)",
+                                                              "tulosTekstiSv": "Ammatillisen perustutkinnon suoritustapa (ops / reformi) lukuarvoksi (2015 / 2017) (sv)",
+                                                              "tulosTekstiEn": "Ammatillisen perustutkinnon suoritustapa (ops / reformi) lukuarvoksi (2015 / 2017) (en)",
+                                                              "tallennaTulos": true,
+                                                              "omaopintopolku": true,
+                                                              "arvokonvertteriparametrit": [
+                                                                {
+                                                                  "paluuarvo": "2015",
+                                                                  "arvo": "ops",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "2017",
+                                                                  "arvo": "reformi",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "arvovalikonvertteriparametrit": [],
+                                                              "syoteparametrit": [],
+                                                              "funktioargumentit": [],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 558893399
+                                                            },
+                                                            "indeksi": 1,
+                                                            "id": 558893403
+                                                          }
+                                                        ],
+                                                        "valintaperusteviitteet": [],
+                                                        "id": 558893402
+                                                      },
+                                                      "indeksi": 1,
+                                                      "id": 558893406
+                                                    }
+                                                  ],
+                                                  "valintaperusteviitteet": [],
+                                                  "id": 558893405
+                                                },
+                                                "indeksi": 1,
+                                                "id": 560515993
+                                              },
+                                              {
+                                                "funktiokutsu": {
+                                                  "funktionimi": "LUKUARVO",
+                                                  "tulosTunniste": null,
+                                                  "tulosTekstiFi": null,
+                                                  "tulosTekstiSv": null,
+                                                  "tulosTekstiEn": null,
+                                                  "tallennaTulos": false,
+                                                  "omaopintopolku": false,
+                                                  "arvokonvertteriparametrit": [],
+                                                  "arvovalikonvertteriparametrit": [],
+                                                  "syoteparametrit": [
+                                                    {
+                                                      "avain": "luku",
+                                                      "arvo": "2017"
+                                                    }
+                                                  ],
+                                                  "funktioargumentit": [],
+                                                  "valintaperusteviitteet": [],
+                                                  "id": 560515990
+                                                },
+                                                "indeksi": 2,
+                                                "id": 560515994
+                                              }
+                                            ],
+                                            "valintaperusteviitteet": [],
+                                            "id": 560515992
+                                          },
+                                          "indeksi": 1,
+                                          "id": 560515998
+                                        }
+                                      ],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560515997
+                                    },
+                                    "indeksi": 3,
+                                    "id": 560516004
+                                  },
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "NIMETTYLUKUARVO",
+                                      "tulosTunniste": null,
+                                      "tulosTekstiFi": null,
+                                      "tulosTekstiSv": null,
+                                      "tulosTekstiEn": null,
+                                      "tallennaTulos": false,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [
+                                        {
+                                          "avain": "nimi",
+                                          "arvo": "Ops-mallisen ammatillisen perustutkinnon pisteet"
+                                        }
+                                      ],
+                                      "funktioargumentit": [
+                                        {
+                                          "funktiokutsu": {
+                                            "funktionimi": "SUMMA",
+                                            "tulosTunniste": "amm_ops-tutkinnon_pisteet",
+                                            "tulosTekstiFi": "Ops-mallisen ammatillisen perustutkinnon pisteet",
+                                            "tulosTekstiSv": "Ops-mallisen ammatillisen perustutkinnon pisteet (sv)",
+                                            "tulosTekstiEn": "Ops-mallisen ammatillisen perustutkinnon pisteet (en)",
+                                            "tallennaTulos": true,
+                                            "omaopintopolku": true,
+                                            "arvokonvertteriparametrit": [],
+                                            "arvovalikonvertteriparametrit": [],
+                                            "syoteparametrit": [],
+                                            "funktioargumentit": [
+                                              {
+                                                "funktiokutsu": {
+                                                  "funktionimi": "NIMETTYLUKUARVO",
+                                                  "tulosTunniste": null,
+                                                  "tulosTekstiFi": null,
+                                                  "tulosTekstiSv": null,
+                                                  "tulosTekstiEn": null,
+                                                  "tallennaTulos": false,
+                                                  "omaopintopolku": false,
+                                                  "arvokonvertteriparametrit": [],
+                                                  "arvovalikonvertteriparametrit": [],
+                                                  "syoteparametrit": [
+                                                    {
+                                                      "avain": "nimi",
+                                                      "arvo": "Ammatillisen vanhanmallisen tutkinnon keskiarvosta (ops, 1–3) saatavat pisteet"
+                                                    }
+                                                  ],
+                                                  "funktioargumentit": [
+                                                    {
+                                                      "funktiokutsu": {
+                                                        "funktionimi": "SUMMA",
+                                                        "tulosTunniste": "amm_ops_tutkinnon_pisteet",
+                                                        "tulosTekstiFi": "Pisteet ammatillisesta ops-mallisesta perustutkinnosta",
+                                                        "tulosTekstiSv": "Pisteet ammatillisesta ops-mallisesta perustutkinnosta (sv)",
+                                                        "tulosTekstiEn": "Pisteet ammatillisesta ops-mallisesta perustutkinnosta (en)",
+                                                        "tallennaTulos": true,
+                                                        "omaopintopolku": true,
+                                                        "arvokonvertteriparametrit": [],
+                                                        "arvovalikonvertteriparametrit": [],
+                                                        "syoteparametrit": [],
+                                                        "funktioargumentit": [
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "LUKUARVO",
+                                                              "tulosTunniste": null,
+                                                              "tulosTekstiFi": null,
+                                                              "tulosTekstiSv": null,
+                                                              "tulosTekstiEn": null,
+                                                              "tallennaTulos": false,
+                                                              "omaopintopolku": false,
+                                                              "arvokonvertteriparametrit": [],
+                                                              "arvovalikonvertteriparametrit": [],
+                                                              "syoteparametrit": [
+                                                                {
+                                                                  "avain": "luku",
+                                                                  "arvo": "0"
+                                                                }
+                                                              ],
+                                                              "funktioargumentit": [],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 558892760
+                                                            },
+                                                            "indeksi": 1,
+                                                            "id": 558892954
+                                                          },
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "KONVERTOILUKUARVO",
+                                                              "tulosTunniste": null,
+                                                              "tulosTekstiFi": null,
+                                                              "tulosTekstiSv": null,
+                                                              "tulosTekstiEn": null,
+                                                              "tallennaTulos": false,
+                                                              "omaopintopolku": false,
+                                                              "arvokonvertteriparametrit": [],
+                                                              "arvovalikonvertteriparametrit": [
+                                                                {
+                                                                  "paluuarvo": "10",
+                                                                  "minValue": "1,21",
+                                                                  "maxValue": "1,23",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "29",
+                                                                  "minValue": "1,65",
+                                                                  "maxValue": "1,68",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "80",
+                                                                  "minValue": "2,82",
+                                                                  "maxValue": "2,84",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "23",
+                                                                  "minValue": "1,49",
+                                                                  "maxValue": "1,51",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "77",
+                                                                  "minValue": "2,77",
+                                                                  "maxValue": "2,78",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "81",
+                                                                  "minValue": "2,84",
+                                                                  "maxValue": "2,86",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "16",
+                                                                  "minValue": "1,34",
+                                                                  "maxValue": "1,36",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "4",
+                                                                  "minValue": "1,09",
+                                                                  "maxValue": "1,11",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "44",
+                                                                  "minValue": "2,05",
+                                                                  "maxValue": "2,08",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "50",
+                                                                  "minValue": "2,19",
+                                                                  "maxValue": "2,21",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "85",
+                                                                  "minValue": "2,91",
+                                                                  "maxValue": "2,93",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "32",
+                                                                  "minValue": "1,73",
+                                                                  "maxValue": "1,76",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "62",
+                                                                  "minValue": "2,45",
+                                                                  "maxValue": "2,48",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "41",
+                                                                  "minValue": "1,97",
+                                                                  "maxValue": "2,00",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "82",
+                                                                  "minValue": "2,86",
+                                                                  "maxValue": "2,87",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "52",
+                                                                  "minValue": "2,23",
+                                                                  "maxValue": "2,26",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "64",
+                                                                  "minValue": "2,50",
+                                                                  "maxValue": "2,52",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "26",
+                                                                  "minValue": "1,57",
+                                                                  "maxValue": "1,59",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "46",
+                                                                  "minValue": "2,10",
+                                                                  "maxValue": "2,12",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "90",
+                                                                  "minValue": "3",
+                                                                  "maxValue": "3",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "43",
+                                                                  "minValue": "2,03",
+                                                                  "maxValue": "2,05",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "54",
+                                                                  "minValue": "2,28",
+                                                                  "maxValue": "2,30",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "11",
+                                                                  "minValue": "1,23",
+                                                                  "maxValue": "1,26",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "33",
+                                                                  "minValue": "1,76",
+                                                                  "maxValue": "1,78",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "86",
+                                                                  "minValue": "2,93",
+                                                                  "maxValue": "2,95",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "14",
+                                                                  "minValue": "1,30",
+                                                                  "maxValue": "1,32",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "69",
+                                                                  "minValue": "2,61",
+                                                                  "maxValue": "2,63",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "25",
+                                                                  "minValue": "1,54",
+                                                                  "maxValue": "1,57",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "13",
+                                                                  "minValue": "1,28",
+                                                                  "maxValue": "1,30",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "35",
+                                                                  "minValue": "1,81",
+                                                                  "maxValue": "1,84",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "89",
+                                                                  "minValue": "2,98",
+                                                                  "maxValue": "3",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "27",
+                                                                  "minValue": "1,59",
+                                                                  "maxValue": "1,62",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "49",
+                                                                  "minValue": "2,17",
+                                                                  "maxValue": "2,19",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "67",
+                                                                  "minValue": "2,56",
+                                                                  "maxValue": "2,59",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "18",
+                                                                  "minValue": "1,38",
+                                                                  "maxValue": "1,40",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "55",
+                                                                  "minValue": "2,30",
+                                                                  "maxValue": "2,32",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "47",
+                                                                  "minValue": "2,12",
+                                                                  "maxValue": "2,15",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "59",
+                                                                  "minValue": "2,39",
+                                                                  "maxValue": "2,41",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "38",
+                                                                  "minValue": "1,89",
+                                                                  "maxValue": "1,92",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "88",
+                                                                  "minValue": "2,96",
+                                                                  "maxValue": "2,98",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "42",
+                                                                  "minValue": "2,00",
+                                                                  "maxValue": "2,03",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "24",
+                                                                  "minValue": "1,51",
+                                                                  "maxValue": "1,54",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "22",
+                                                                  "minValue": "1,47",
+                                                                  "maxValue": "1,49",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "66",
+                                                                  "minValue": "2,54",
+                                                                  "maxValue": "2,56",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "3",
+                                                                  "minValue": "1,07",
+                                                                  "maxValue": "1,09",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "58",
+                                                                  "minValue": "2,37",
+                                                                  "maxValue": "2,39",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "36",
+                                                                  "minValue": "1,84",
+                                                                  "maxValue": "1,86",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "7",
+                                                                  "minValue": "1,15",
+                                                                  "maxValue": "1,17",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "6",
+                                                                  "minValue": "1,13",
+                                                                  "maxValue": "1,15",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "60",
+                                                                  "minValue": "2,41",
+                                                                  "maxValue": "2,43",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "61",
+                                                                  "minValue": "2,43",
+                                                                  "maxValue": "2,45",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "56",
+                                                                  "minValue": "2,32",
+                                                                  "maxValue": "2,34",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "68",
+                                                                  "minValue": "2,59",
+                                                                  "maxValue": "2,61",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "40",
+                                                                  "minValue": "1,95",
+                                                                  "maxValue": "1,97",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "39",
+                                                                  "minValue": "1,92",
+                                                                  "maxValue": "1,95",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "74",
+                                                                  "minValue": "2,71",
+                                                                  "maxValue": "2,73",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "73",
+                                                                  "minValue": "2,69",
+                                                                  "maxValue": "2,71",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "83",
+                                                                  "minValue": "2,87",
+                                                                  "maxValue": "2,89",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "71",
+                                                                  "minValue": "2,65",
+                                                                  "maxValue": "2,67",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "9",
+                                                                  "minValue": "1,19",
+                                                                  "maxValue": "1,21",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "53",
+                                                                  "minValue": "2,26",
+                                                                  "maxValue": "2,28",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "57",
+                                                                  "minValue": "2,34",
+                                                                  "maxValue": "2,37",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "65",
+                                                                  "minValue": "2,52",
+                                                                  "maxValue": "2,54",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "0",
+                                                                  "minValue": "1",
+                                                                  "maxValue": "0",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "31",
+                                                                  "minValue": "1,70",
+                                                                  "maxValue": "1,73",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "20",
+                                                                  "minValue": "1,42",
+                                                                  "maxValue": "1,44",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "51",
+                                                                  "minValue": "2,21",
+                                                                  "maxValue": "2,23",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "78",
+                                                                  "minValue": "2,78",
+                                                                  "maxValue": "2,80",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "70",
+                                                                  "minValue": "2,63",
+                                                                  "maxValue": "2,65",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "75",
+                                                                  "minValue": "2,73",
+                                                                  "maxValue": "2,75",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "72",
+                                                                  "minValue": "2,67",
+                                                                  "maxValue": "2,69",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "84",
+                                                                  "minValue": "2,89",
+                                                                  "maxValue": "2,91",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "30",
+                                                                  "minValue": "1,68",
+                                                                  "maxValue": "1,70",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "34",
+                                                                  "minValue": "1,78",
+                                                                  "maxValue": "1,81",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "87",
+                                                                  "minValue": "2,95",
+                                                                  "maxValue": "2,96",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "19",
+                                                                  "minValue": "1,40",
+                                                                  "maxValue": "1,42",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "12",
+                                                                  "minValue": "1,26",
+                                                                  "maxValue": "1,28",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "17",
+                                                                  "minValue": "1,36",
+                                                                  "maxValue": "1,38",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "21",
+                                                                  "minValue": "1,44",
+                                                                  "maxValue": "1,47",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "63",
+                                                                  "minValue": "2,48",
+                                                                  "maxValue": "2,50",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "48",
+                                                                  "minValue": "2,15",
+                                                                  "maxValue": "2,17",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "5",
+                                                                  "minValue": "1,11",
+                                                                  "maxValue": "1,13",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "79",
+                                                                  "minValue": "2,80",
+                                                                  "maxValue": "2,82",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "15",
+                                                                  "minValue": "1,32",
+                                                                  "maxValue": "1,34",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "76",
+                                                                  "minValue": "2,75",
+                                                                  "maxValue": "2,77",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "45",
+                                                                  "minValue": "2,08",
+                                                                  "maxValue": "2,10",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "37",
+                                                                  "minValue": "1,86",
+                                                                  "maxValue": "1,89",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "2",
+                                                                  "minValue": "1,05",
+                                                                  "maxValue": "1,07",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "8",
+                                                                  "minValue": "1,17",
+                                                                  "maxValue": "1,19",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "28",
+                                                                  "minValue": "1,62",
+                                                                  "maxValue": "1,65",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "paluuarvo": "1",
+                                                                  "minValue": "1,02",
+                                                                  "maxValue": "1,05",
+                                                                  "palautaHaettuArvo": "false",
+                                                                  "hylkaysperuste": "false",
+                                                                  "kuvaukset": {
+                                                                    "tekstit": []
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "syoteparametrit": [],
+                                                              "funktioargumentit": [
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "ITEROIAMMATILLISETOSAT",
+                                                                    "tulosTunniste": "iteri_amm_tutkinnon_osat",
+                                                                    "tulosTekstiFi": "Iteroi ammatillisen perustutkinnon osat",
+                                                                    "tulosTekstiSv": "Iteroi ammatillisen perustutkinnon osat (sv)",
+                                                                    "tulosTekstiEn": "Iteroi ammatillisen perustutkinnon osat (en)",
+                                                                    "tallennaTulos": true,
+                                                                    "omaopintopolku": false,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [],
+                                                                    "funktioargumentit": [
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "PAINOTETTUKESKIARVO",
+                                                                          "tulosTunniste": "amm_ops_painotettu_keskiarvo",
+                                                                          "tulosTekstiFi": "Ammatillisten tutkinnon keskiarvo",
+                                                                          "tulosTekstiSv": "Ammatillisten tutkinnon keskiarvo (sv)",
+                                                                          "tulosTekstiEn": "Ammatillisten tutkinnon keskiarvo (en)",
+                                                                          "tallennaTulos": true,
+                                                                          "omaopintopolku": true,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLISENOSANLAAJUUS",
+                                                                                "tulosTunniste": "amm_tutkinnon_osan_laajuus",
+                                                                                "tulosTekstiFi": "Ammatillisten perustutkinnon osan laajuus",
+                                                                                "tulosTekstiSv": "Ammatillisten perustutkinnon osan laajuus (sv)",
+                                                                                "tulosTekstiEn": "Ammatillisten perustutkinnon osan laajuus (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558892762
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558892765
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLISENOSANARVOSANA",
+                                                                                "tulosTunniste": "amm_tutkinnon_osan_arvosana",
+                                                                                "tulosTekstiFi": "Ammatillisen tutkinnon osan arvosana",
+                                                                                "tulosTekstiSv": "Ammatillisen tutkinnon osan arvosana (sv)",
+                                                                                "tulosTekstiEn": "Ammatillisen tutkinnon osan arvosana (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558892763
+                                                                              },
+                                                                              "indeksi": 2,
+                                                                              "id": 558892766
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558892764
+                                                                        },
+                                                                        "indeksi": 1,
+                                                                        "id": 558892768
+                                                                      }
+                                                                    ],
+                                                                    "valintaperusteviitteet": [],
+                                                                    "id": 558892767
+                                                                  },
+                                                                  "indeksi": 1,
+                                                                  "id": 558892952
+                                                                }
+                                                              ],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 558892860
+                                                            },
+                                                            "indeksi": 2,
+                                                            "id": 558892955
+                                                          }
+                                                        ],
+                                                        "valintaperusteviitteet": [],
+                                                        "id": 558892953
+                                                      },
+                                                      "indeksi": 1,
+                                                      "id": 558892957
+                                                    }
+                                                  ],
+                                                  "valintaperusteviitteet": [],
+                                                  "id": 558892956
+                                                },
+                                                "indeksi": 2,
+                                                "id": 558893527
+                                              },
+                                              {
+                                                "funktiokutsu": {
+                                                  "funktionimi": "LUKUARVO",
+                                                  "tulosTunniste": null,
+                                                  "tulosTekstiFi": null,
+                                                  "tulosTekstiSv": null,
+                                                  "tulosTekstiEn": null,
+                                                  "tallennaTulos": false,
+                                                  "omaopintopolku": false,
+                                                  "arvokonvertteriparametrit": [],
+                                                  "arvovalikonvertteriparametrit": [],
+                                                  "syoteparametrit": [
+                                                    {
+                                                      "avain": "luku",
+                                                      "arvo": "0"
+                                                    }
+                                                  ],
+                                                  "funktioargumentit": [],
+                                                  "valintaperusteviitteet": [],
+                                                  "id": 558893523
+                                                },
+                                                "indeksi": 3,
+                                                "id": 558893528
+                                              },
+                                              {
+                                                "funktiokutsu": {
+                                                  "funktionimi": "NIMETTYLUKUARVO",
+                                                  "tulosTunniste": null,
+                                                  "tulosTekstiFi": null,
+                                                  "tulosTekstiSv": null,
+                                                  "tulosTekstiEn": null,
+                                                  "tallennaTulos": false,
+                                                  "omaopintopolku": false,
+                                                  "arvokonvertteriparametrit": [],
+                                                  "arvovalikonvertteriparametrit": [],
+                                                  "syoteparametrit": [
+                                                    {
+                                                      "avain": "nimi",
+                                                      "arvo": "Ammatillisen ops-mallisen tutkinnon yhteisten tutkinnon osien pisteet"
+                                                    }
+                                                  ],
+                                                  "funktioargumentit": [
+                                                    {
+                                                      "funktiokutsu": {
+                                                        "funktionimi": "SUMMA",
+                                                        "tulosTunniste": "amm_ytojen_pisteet",
+                                                        "tulosTekstiFi": "Ammatillisen tutkinnon yhteisten tutkinnon osien pisteet",
+                                                        "tulosTekstiSv": "Ammatillisen tutkinnon yhteisten tutkinnon osien pisteet (sv)",
+                                                        "tulosTekstiEn": "Ammatillisen tutkinnon yhteisten tutkinnon osien pisteet (en)",
+                                                        "tallennaTulos": true,
+                                                        "omaopintopolku": true,
+                                                        "arvokonvertteriparametrit": [],
+                                                        "arvovalikonvertteriparametrit": [],
+                                                        "syoteparametrit": [],
+                                                        "funktioargumentit": [
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "NIMETTYLUKUARVO",
+                                                              "tulosTunniste": null,
+                                                              "tulosTekstiFi": null,
+                                                              "tulosTekstiSv": null,
+                                                              "tulosTekstiEn": null,
+                                                              "tallennaTulos": false,
+                                                              "omaopintopolku": false,
+                                                              "arvokonvertteriparametrit": [],
+                                                              "arvovalikonvertteriparametrit": [],
+                                                              "syoteparametrit": [
+                                                                {
+                                                                  "avain": "nimi",
+                                                                  "arvo": "Ammatilliinen yto viestintä- ja vuorovaikutusosaaminen"
+                                                                }
+                                                              ],
+                                                              "funktioargumentit": [
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "MAKSIMI",
+                                                                    "tulosTunniste": "amm_yto_viestinta-ja_vuorovaikutus",
+                                                                    "tulosTekstiFi": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen",
+                                                                    "tulosTekstiSv": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen (sv)",
+                                                                    "tulosTekstiEn": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen (en)",
+                                                                    "tallennaTulos": true,
+                                                                    "omaopintopolku": true,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [],
+                                                                    "funktioargumentit": [
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "JOS",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                "tulosTunniste": "amm_yto_viestinta_101053_1_3",
+                                                                                "tulosTekstiFi": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–3",
+                                                                                "tulosTekstiSv": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–3 (sv)",
+                                                                                "tulosTekstiEn": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–3 (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "arvo": "3",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "13",
+                                                                                    "arvo": "2",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "2",
+                                                                                    "arvo": "1",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [
+                                                                                  {
+                                                                                    "tunniste": "101053",
+                                                                                    "kuvaus": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–3",
+                                                                                    "lahde": "HAETTAVA_ARVO",
+                                                                                    "onPakollinen": false,
+                                                                                    "epasuoraViittaus": false,
+                                                                                    "indeksi": 2,
+                                                                                    "vaatiiOsallistumisen": true,
+                                                                                    "syotettavissaKaikille": true,
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    },
+                                                                                    "syotettavanarvontyyppi": null,
+                                                                                    "tilastoidaan": false
+                                                                                  }
+                                                                                ],
+                                                                                "id": 558893115
+                                                                              },
+                                                                              "indeksi": 2,
+                                                                              "id": 558893146
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "JOS",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "0"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893138
+                                                                                    },
+                                                                                    "indeksi": 3,
+                                                                                    "id": 558893143
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                      "tulosTunniste": "amm_yto_viestinta_101053_1_5",
+                                                                                      "tulosTekstiFi": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–5",
+                                                                                      "tulosTekstiSv": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–5 (sv)",
+                                                                                      "tulosTekstiEn": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–5 (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [
+                                                                                        {
+                                                                                          "paluuarvo": "10",
+                                                                                          "arvo": "3",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "15",
+                                                                                          "arvo": "4",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "5",
+                                                                                          "arvo": "2",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "20",
+                                                                                          "arvo": "5",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "1",
+                                                                                          "arvo": "1",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        }
+                                                                                      ],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [
+                                                                                        {
+                                                                                          "tunniste": "101053",
+                                                                                          "kuvaus": "YTO:n \"Viestintä- ja vuorovaikutusosaaminen\" (101053) pisteet asteikolta 1–5",
+                                                                                          "lahde": "HAETTAVA_ARVO",
+                                                                                          "onPakollinen": false,
+                                                                                          "epasuoraViittaus": false,
+                                                                                          "indeksi": 2,
+                                                                                          "vaatiiOsallistumisen": true,
+                                                                                          "syotettavissaKaikille": true,
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          },
+                                                                                          "syotettavanarvontyyppi": null,
+                                                                                          "tilastoidaan": false
+                                                                                        }
+                                                                                      ],
+                                                                                      "id": 558893131
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893142
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "YHTASUURI",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen yto:n viestintä (101053) asteikko"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                                  "tulosTunniste": "amm_yto_viestinta_101053_asteikko",
+                                                                                                  "tulosTekstiFi": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen 101053 arvosteluasteikko",
+                                                                                                  "tulosTekstiSv": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen 101053 arvosteluasteikko (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen 101053 arvosteluasteikko (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [
+                                                                                                    {
+                                                                                                      "paluuarvo": "5",
+                                                                                                      "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "paluuarvo": "3",
+                                                                                                      "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [
+                                                                                                    {
+                                                                                                      "tunniste": "101053",
+                                                                                                      "kuvaus": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen toinen mahdollinen koodi 101053",
+                                                                                                      "lahde": "HAETTAVA_ARVO",
+                                                                                                      "onPakollinen": false,
+                                                                                                      "epasuoraViittaus": false,
+                                                                                                      "indeksi": 2,
+                                                                                                      "vaatiiOsallistumisen": true,
+                                                                                                      "syotettavissaKaikille": true,
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      },
+                                                                                                      "syotettavanarvontyyppi": null,
+                                                                                                      "tilastoidaan": false
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "id": 558892554
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558892559
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558892558
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893123
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "LUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "luku",
+                                                                                                "arvo": "5"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893120
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558893124
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893122
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893141
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893140
+                                                                              },
+                                                                              "indeksi": 3,
+                                                                              "id": 558893147
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "YHTASUURI",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "NIMETTYLUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "nimi",
+                                                                                          "arvo": "Ammatillisen yto:n viestintä (101053) asteikko"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                            "tulosTunniste": "amm_yto_viestinta_101053_asteikko",
+                                                                                            "tulosTekstiFi": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen 101053 arvosteluasteikko",
+                                                                                            "tulosTekstiSv": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen 101053 arvosteluasteikko (sv)",
+                                                                                            "tulosTekstiEn": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen 101053 arvosteluasteikko (en)",
+                                                                                            "tallennaTulos": true,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [
+                                                                                              {
+                                                                                                "paluuarvo": "5",
+                                                                                                "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "paluuarvo": "3",
+                                                                                                "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              }
+                                                                                            ],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [
+                                                                                              {
+                                                                                                "tunniste": "101053",
+                                                                                                "kuvaus": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen toinen mahdollinen koodi 101053",
+                                                                                                "lahde": "HAETTAVA_ARVO",
+                                                                                                "onPakollinen": false,
+                                                                                                "epasuoraViittaus": false,
+                                                                                                "indeksi": 2,
+                                                                                                "vaatiiOsallistumisen": true,
+                                                                                                "syotettavissaKaikille": true,
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                },
+                                                                                                "syotettavanarvontyyppi": null,
+                                                                                                "tilastoidaan": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "id": 558892554
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558892559
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558892558
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893109
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "3"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893106
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893110
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893108
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558893145
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558893144
+                                                                        },
+                                                                        "indeksi": 1,
+                                                                        "id": 558893191
+                                                                      },
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "JOS",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                "tulosTunniste": "amm_yto_viestinta_400012_1_3",
+                                                                                "tulosTekstiFi": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–3",
+                                                                                "tulosTekstiSv": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–3 (sv)",
+                                                                                "tulosTekstiEn": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–3 (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "arvo": "3",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "13",
+                                                                                    "arvo": "2",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "2",
+                                                                                    "arvo": "1",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [
+                                                                                  {
+                                                                                    "tunniste": "400012",
+                                                                                    "kuvaus": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–3",
+                                                                                    "lahde": "HAETTAVA_ARVO",
+                                                                                    "onPakollinen": false,
+                                                                                    "epasuoraViittaus": false,
+                                                                                    "indeksi": 2,
+                                                                                    "vaatiiOsallistumisen": true,
+                                                                                    "syotettavissaKaikille": true,
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    },
+                                                                                    "syotettavanarvontyyppi": null,
+                                                                                    "tilastoidaan": false
+                                                                                  }
+                                                                                ],
+                                                                                "id": 558893157
+                                                                              },
+                                                                              "indeksi": 2,
+                                                                              "id": 558893188
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "JOS",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "YHTASUURI",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "LUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "luku",
+                                                                                                "arvo": "5"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893162
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558893166
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammmatillisen yto:n viestintä (400012) asteikko"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                                  "tulosTunniste": "amm_yto_viestinta_400012_arviointiasteikko",
+                                                                                                  "tulosTekstiFi": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko",
+                                                                                                  "tulosTekstiSv": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko  (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [
+                                                                                                    {
+                                                                                                      "paluuarvo": "5",
+                                                                                                      "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "paluuarvo": "3",
+                                                                                                      "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [
+                                                                                                    {
+                                                                                                      "tunniste": "400012",
+                                                                                                      "kuvaus": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                                      "lahde": "HAETTAVA_ARVO",
+                                                                                                      "onPakollinen": false,
+                                                                                                      "epasuoraViittaus": false,
+                                                                                                      "indeksi": 2,
+                                                                                                      "vaatiiOsallistumisen": true,
+                                                                                                      "syotettavissaKaikille": true,
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      },
+                                                                                                      "syotettavanarvontyyppi": null,
+                                                                                                      "tilastoidaan": false
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "id": 558892962
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558892967
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558892966
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893165
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893164
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893183
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                      "tulosTunniste": "amm_yto_viesinta_400012_1_5",
+                                                                                      "tulosTekstiFi": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–5",
+                                                                                      "tulosTekstiSv": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–5 (sv)",
+                                                                                      "tulosTekstiEn": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–5 (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [
+                                                                                        {
+                                                                                          "paluuarvo": "1",
+                                                                                          "arvo": "1",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "20",
+                                                                                          "arvo": "5",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "15",
+                                                                                          "arvo": "4",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "5",
+                                                                                          "arvo": "2",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "10",
+                                                                                          "arvo": "3",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        }
+                                                                                      ],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [
+                                                                                        {
+                                                                                          "tunniste": "400012",
+                                                                                          "kuvaus": "YTO:n Viestintä- ja vuorovaikutusosaaminen (400012) arvosanan pisteet asteikolla 1–5",
+                                                                                          "lahde": "HAETTAVA_ARVO",
+                                                                                          "onPakollinen": false,
+                                                                                          "epasuoraViittaus": false,
+                                                                                          "indeksi": 2,
+                                                                                          "vaatiiOsallistumisen": true,
+                                                                                          "syotettavissaKaikille": true,
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          },
+                                                                                          "syotettavanarvontyyppi": null,
+                                                                                          "tilastoidaan": false
+                                                                                        }
+                                                                                      ],
+                                                                                      "id": 558893173
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893184
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "0"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893180
+                                                                                    },
+                                                                                    "indeksi": 3,
+                                                                                    "id": 558893185
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893182
+                                                                              },
+                                                                              "indeksi": 3,
+                                                                              "id": 558893189
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "YHTASUURI",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "3"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893148
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893152
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "NIMETTYLUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "nimi",
+                                                                                          "arvo": "Ammmatillisen yto:n viestintä (400012) asteikko"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                            "tulosTunniste": "amm_yto_viestinta_400012_arviointiasteikko",
+                                                                                            "tulosTekstiFi": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko",
+                                                                                            "tulosTekstiSv": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko  (sv)",
+                                                                                            "tulosTekstiEn": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko (en)",
+                                                                                            "tallennaTulos": true,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [
+                                                                                              {
+                                                                                                "paluuarvo": "5",
+                                                                                                "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "paluuarvo": "3",
+                                                                                                "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              }
+                                                                                            ],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [
+                                                                                              {
+                                                                                                "tunniste": "400012",
+                                                                                                "kuvaus": "Ammatillisen yto:n Viestintä- ja vuorovaikutusosaaminen (400012) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                                "lahde": "HAETTAVA_ARVO",
+                                                                                                "onPakollinen": false,
+                                                                                                "epasuoraViittaus": false,
+                                                                                                "indeksi": 2,
+                                                                                                "vaatiiOsallistumisen": true,
+                                                                                                "syotettavissaKaikille": true,
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                },
+                                                                                                "syotettavanarvontyyppi": null,
+                                                                                                "tilastoidaan": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "id": 558892962
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558892967
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558892966
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893151
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893150
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558893187
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558893186
+                                                                        },
+                                                                        "indeksi": 2,
+                                                                        "id": 558893192
+                                                                      }
+                                                                    ],
+                                                                    "valintaperusteviitteet": [],
+                                                                    "id": 558893190
+                                                                  },
+                                                                  "indeksi": 1,
+                                                                  "id": 558893194
+                                                                }
+                                                              ],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 558893193
+                                                            },
+                                                            "indeksi": 1,
+                                                            "id": 558894194
+                                                          },
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "NIMETTYLUKUARVO",
+                                                              "tulosTunniste": null,
+                                                              "tulosTekstiFi": null,
+                                                              "tulosTekstiSv": null,
+                                                              "tulosTekstiEn": null,
+                                                              "tallennaTulos": false,
+                                                              "omaopintopolku": false,
+                                                              "arvokonvertteriparametrit": [],
+                                                              "arvovalikonvertteriparametrit": [],
+                                                              "syoteparametrit": [
+                                                                {
+                                                                  "avain": "nimi",
+                                                                  "arvo": "Ammatillinen yto yhteiskunta- ja työelämäosaaminen"
+                                                                }
+                                                              ],
+                                                              "funktioargumentit": [
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "MAKSIMI",
+                                                                    "tulosTunniste": "amm_yto_viestinta-ja_vuorovaikutus",
+                                                                    "tulosTekstiFi": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen",
+                                                                    "tulosTekstiSv": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen (sv)",
+                                                                    "tulosTekstiEn": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen (en)",
+                                                                    "tallennaTulos": true,
+                                                                    "omaopintopolku": true,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [],
+                                                                    "funktioargumentit": [
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "JOS",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "JOS",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "YHTASUURI",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen yto:n yhteiskunta (101055) asteikko"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                                  "tulosTunniste": "amm_yto_yhteiskunta_101055_arviointiasteikko",
+                                                                                                  "tulosTekstiFi": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko",
+                                                                                                  "tulosTekstiSv": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [
+                                                                                                    {
+                                                                                                      "paluuarvo": "3",
+                                                                                                      "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "paluuarvo": "5",
+                                                                                                      "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [
+                                                                                                    {
+                                                                                                      "tunniste": "101055",
+                                                                                                      "kuvaus": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko",
+                                                                                                      "lahde": "HAETTAVA_ARVO",
+                                                                                                      "onPakollinen": false,
+                                                                                                      "epasuoraViittaus": false,
+                                                                                                      "indeksi": 2,
+                                                                                                      "vaatiiOsallistumisen": true,
+                                                                                                      "syotettavissaKaikille": true,
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      },
+                                                                                                      "syotettavanarvontyyppi": null,
+                                                                                                      "tilastoidaan": false
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "id": 558892999
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558893004
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893003
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893213
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "LUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "luku",
+                                                                                                "arvo": "5"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893210
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558893214
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893212
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893231
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                      "tulosTunniste": "amm_yto_yhteiskunta_101055_1_5",
+                                                                                      "tulosTekstiFi": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1–5",
+                                                                                      "tulosTekstiSv": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1–5 (sv)",
+                                                                                      "tulosTekstiEn": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1– 5(en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [
+                                                                                        {
+                                                                                          "paluuarvo": "5",
+                                                                                          "arvo": "2",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "20",
+                                                                                          "arvo": "5",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "15",
+                                                                                          "arvo": "4",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "10",
+                                                                                          "arvo": "3",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "1",
+                                                                                          "arvo": "1",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        }
+                                                                                      ],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [
+                                                                                        {
+                                                                                          "tunniste": "101055",
+                                                                                          "kuvaus": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1–5",
+                                                                                          "lahde": "HAETTAVA_ARVO",
+                                                                                          "onPakollinen": false,
+                                                                                          "epasuoraViittaus": false,
+                                                                                          "indeksi": 2,
+                                                                                          "vaatiiOsallistumisen": true,
+                                                                                          "syotettavissaKaikille": true,
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          },
+                                                                                          "syotettavanarvontyyppi": null,
+                                                                                          "tilastoidaan": false
+                                                                                        }
+                                                                                      ],
+                                                                                      "id": 558893221
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893232
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "0"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893228
+                                                                                    },
+                                                                                    "indeksi": 3,
+                                                                                    "id": 558893233
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893230
+                                                                              },
+                                                                              "indeksi": 3,
+                                                                              "id": 558893237
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "YHTASUURI",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "NIMETTYLUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "nimi",
+                                                                                          "arvo": "Ammatillisen yto:n yhteiskunta (101055) asteikko"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                            "tulosTunniste": "amm_yto_yhteiskunta_101055_arviointiasteikko",
+                                                                                            "tulosTekstiFi": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko",
+                                                                                            "tulosTekstiSv": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko (sv)",
+                                                                                            "tulosTekstiEn": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko (en)",
+                                                                                            "tallennaTulos": true,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [
+                                                                                              {
+                                                                                                "paluuarvo": "3",
+                                                                                                "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "paluuarvo": "5",
+                                                                                                "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              }
+                                                                                            ],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [
+                                                                                              {
+                                                                                                "tunniste": "101055",
+                                                                                                "kuvaus": "Ammatillisen yto:n Yhteiskunnassa ja työelämässä tarvittava osaaminen 101055 arviointiasteikko",
+                                                                                                "lahde": "HAETTAVA_ARVO",
+                                                                                                "onPakollinen": false,
+                                                                                                "epasuoraViittaus": false,
+                                                                                                "indeksi": 2,
+                                                                                                "vaatiiOsallistumisen": true,
+                                                                                                "syotettavissaKaikille": true,
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                },
+                                                                                                "syotettavanarvontyyppi": null,
+                                                                                                "tilastoidaan": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "id": 558892999
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893004
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893003
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893199
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "3"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893196
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893200
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893198
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558893235
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                "tulosTunniste": "amm_yto_yhteiskunta_101055_1_3",
+                                                                                "tulosTekstiFi": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1–3",
+                                                                                "tulosTekstiSv": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1–3 (sv)",
+                                                                                "tulosTekstiEn": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1–3 (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "arvo": "3",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "2",
+                                                                                    "arvo": "1",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "13",
+                                                                                    "arvo": "2",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [
+                                                                                  {
+                                                                                    "tunniste": "101055",
+                                                                                    "kuvaus": "YTO:n \"Yhteiskunnassa ja työelämässä tarvittava osaaminen\" (101055) pisteet asteikolta 1–3",
+                                                                                    "lahde": "HAETTAVA_ARVO",
+                                                                                    "onPakollinen": false,
+                                                                                    "epasuoraViittaus": false,
+                                                                                    "indeksi": 2,
+                                                                                    "vaatiiOsallistumisen": true,
+                                                                                    "syotettavissaKaikille": true,
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    },
+                                                                                    "syotettavanarvontyyppi": null,
+                                                                                    "tilastoidaan": false
+                                                                                  }
+                                                                                ],
+                                                                                "id": 558893205
+                                                                              },
+                                                                              "indeksi": 2,
+                                                                              "id": 558893236
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558893234
+                                                                        },
+                                                                        "indeksi": 1,
+                                                                        "id": 558893281
+                                                                      },
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "JOS",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                "tulosTunniste": "amm_yto_yhteiskunta_400014_1_3",
+                                                                                "tulosTekstiFi": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–3",
+                                                                                "tulosTekstiSv": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–3 (sv)",
+                                                                                "tulosTekstiEn": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–3 (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "arvo": "3",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "2",
+                                                                                    "arvo": "1",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "13",
+                                                                                    "arvo": "2",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [
+                                                                                  {
+                                                                                    "tunniste": "400014",
+                                                                                    "kuvaus": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–3",
+                                                                                    "lahde": "HAETTAVA_ARVO",
+                                                                                    "onPakollinen": false,
+                                                                                    "epasuoraViittaus": false,
+                                                                                    "indeksi": 2,
+                                                                                    "vaatiiOsallistumisen": true,
+                                                                                    "syotettavissaKaikille": true,
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    },
+                                                                                    "syotettavanarvontyyppi": null,
+                                                                                    "tilastoidaan": false
+                                                                                  }
+                                                                                ],
+                                                                                "id": 558893247
+                                                                              },
+                                                                              "indeksi": 2,
+                                                                              "id": 558893278
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "YHTASUURI",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "NIMETTYLUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "nimi",
+                                                                                          "arvo": "Ammatillisen yton:n yhteiskunta (400014) asteikko"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                            "tulosTunniste": "amm_yto_yhteiskunta_400014_arviointiasteikko",
+                                                                                            "tulosTekstiFi": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                            "tulosTekstiSv": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5 (sv)",
+                                                                                            "tulosTekstiEn": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5 (en)",
+                                                                                            "tallennaTulos": true,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [
+                                                                                              {
+                                                                                                "paluuarvo": "3",
+                                                                                                "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "paluuarvo": "5",
+                                                                                                "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              }
+                                                                                            ],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [
+                                                                                              {
+                                                                                                "tunniste": "400014",
+                                                                                                "kuvaus": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                                "lahde": "HAETTAVA_ARVO",
+                                                                                                "onPakollinen": false,
+                                                                                                "epasuoraViittaus": false,
+                                                                                                "indeksi": 2,
+                                                                                                "vaatiiOsallistumisen": true,
+                                                                                                "syotettavissaKaikille": true,
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                },
+                                                                                                "syotettavanarvontyyppi": null,
+                                                                                                "tilastoidaan": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "id": 558893009
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893014
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893013
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893241
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "3"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893238
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893242
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893240
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558893277
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "JOS",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "0"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893270
+                                                                                    },
+                                                                                    "indeksi": 3,
+                                                                                    "id": 558893275
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                      "tulosTunniste": "amm_yto_yhteiskunta_400014_1_5",
+                                                                                      "tulosTekstiFi": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–5",
+                                                                                      "tulosTekstiSv": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–5 (sv)",
+                                                                                      "tulosTekstiEn": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–5 (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [
+                                                                                        {
+                                                                                          "paluuarvo": "5",
+                                                                                          "arvo": "2",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "20",
+                                                                                          "arvo": "5",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "15",
+                                                                                          "arvo": "4",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "1",
+                                                                                          "arvo": "1",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "10",
+                                                                                          "arvo": "3",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        }
+                                                                                      ],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [
+                                                                                        {
+                                                                                          "tunniste": "400014",
+                                                                                          "kuvaus": "YTO:n Yhteiskunta- ja työelämäosaaminen (400014) arvosanan pisteet asteikolla 1–5",
+                                                                                          "lahde": "HAETTAVA_ARVO",
+                                                                                          "onPakollinen": false,
+                                                                                          "epasuoraViittaus": false,
+                                                                                          "indeksi": 2,
+                                                                                          "vaatiiOsallistumisen": true,
+                                                                                          "syotettavissaKaikille": true,
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          },
+                                                                                          "syotettavanarvontyyppi": null,
+                                                                                          "tilastoidaan": false
+                                                                                        }
+                                                                                      ],
+                                                                                      "id": 558893263
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893274
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "YHTASUURI",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "LUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "luku",
+                                                                                                "arvo": "5"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893252
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558893256
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen yton:n yhteiskunta (400014) asteikko"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                                  "tulosTunniste": "amm_yto_yhteiskunta_400014_arviointiasteikko",
+                                                                                                  "tulosTekstiFi": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                                  "tulosTekstiSv": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5 (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5 (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [
+                                                                                                    {
+                                                                                                      "paluuarvo": "5",
+                                                                                                      "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "paluuarvo": "3",
+                                                                                                      "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [
+                                                                                                    {
+                                                                                                      "tunniste": "400014",
+                                                                                                      "kuvaus": "Ammatillisen yto:n Yhteiskunta- ja työelämäosaaminen (400014) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                                      "lahde": "HAETTAVA_ARVO",
+                                                                                                      "onPakollinen": false,
+                                                                                                      "epasuoraViittaus": false,
+                                                                                                      "indeksi": 2,
+                                                                                                      "vaatiiOsallistumisen": true,
+                                                                                                      "syotettavissaKaikille": true,
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      },
+                                                                                                      "syotettavanarvontyyppi": null,
+                                                                                                      "tilastoidaan": false
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "id": 558893009
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558893014
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893013
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893255
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893254
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893273
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893272
+                                                                              },
+                                                                              "indeksi": 3,
+                                                                              "id": 558893279
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558893276
+                                                                        },
+                                                                        "indeksi": 2,
+                                                                        "id": 558893282
+                                                                      }
+                                                                    ],
+                                                                    "valintaperusteviitteet": [],
+                                                                    "id": 558893280
+                                                                  },
+                                                                  "indeksi": 1,
+                                                                  "id": 558893284
+                                                                }
+                                                              ],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 558893283
+                                                            },
+                                                            "indeksi": 3,
+                                                            "id": 558894196
+                                                          },
+                                                          {
+                                                            "funktiokutsu": {
+                                                              "funktionimi": "NIMETTYLUKUARVO",
+                                                              "tulosTunniste": null,
+                                                              "tulosTekstiFi": null,
+                                                              "tulosTekstiSv": null,
+                                                              "tulosTekstiEn": null,
+                                                              "tallennaTulos": false,
+                                                              "omaopintopolku": false,
+                                                              "arvokonvertteriparametrit": [],
+                                                              "arvovalikonvertteriparametrit": [],
+                                                              "syoteparametrit": [
+                                                                {
+                                                                  "avain": "nimi",
+                                                                  "arvo": "Ammatillinen yto matemaattis-luonnontieteellinen osaaminen"
+                                                                }
+                                                              ],
+                                                              "funktioargumentit": [
+                                                                {
+                                                                  "funktiokutsu": {
+                                                                    "funktionimi": "MAKSIMI",
+                                                                    "tulosTunniste": "amm_yto_viestinta-ja_vuorovaikutus",
+                                                                    "tulosTekstiFi": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen",
+                                                                    "tulosTekstiSv": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen (sv)",
+                                                                    "tulosTekstiEn": "Ammatillinen yto viestintä- ja vuorovaikutusosaaminen (en)",
+                                                                    "tallennaTulos": true,
+                                                                    "omaopintopolku": true,
+                                                                    "arvokonvertteriparametrit": [],
+                                                                    "arvovalikonvertteriparametrit": [],
+                                                                    "syoteparametrit": [],
+                                                                    "funktioargumentit": [
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "JOS",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                "tulosTunniste": "amm_yto_matlu_400013_1_3",
+                                                                                "tulosTekstiFi": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–3",
+                                                                                "tulosTekstiSv": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–3 (sv)",
+                                                                                "tulosTekstiEn": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–3 (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "13",
+                                                                                    "arvo": "2",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "arvo": "3",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "2",
+                                                                                    "arvo": "1",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [
+                                                                                  {
+                                                                                    "tunniste": "400013",
+                                                                                    "kuvaus": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–3",
+                                                                                    "lahde": "HAETTAVA_ARVO",
+                                                                                    "onPakollinen": false,
+                                                                                    "epasuoraViittaus": false,
+                                                                                    "indeksi": 2,
+                                                                                    "vaatiiOsallistumisen": true,
+                                                                                    "syotettavissaKaikille": true,
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    },
+                                                                                    "syotettavanarvontyyppi": null,
+                                                                                    "tilastoidaan": false
+                                                                                  }
+                                                                                ],
+                                                                                "id": 558893067
+                                                                              },
+                                                                              "indeksi": 2,
+                                                                              "id": 558893098
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "JOS",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "YHTASUURI",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "LUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "luku",
+                                                                                                "arvo": "5"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893072
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558893076
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen yto:n matlu (400013) asteikko"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                                  "tulosTunniste": "amm_yto_matlu_400013_arviointiasteikko",
+                                                                                                  "tulosTekstiFi": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko",
+                                                                                                  "tulosTekstiSv": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [
+                                                                                                    {
+                                                                                                      "paluuarvo": "5",
+                                                                                                      "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "paluuarvo": "3",
+                                                                                                      "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [
+                                                                                                    {
+                                                                                                      "tunniste": "400013",
+                                                                                                      "kuvaus": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                                      "lahde": "HAETTAVA_ARVO",
+                                                                                                      "onPakollinen": false,
+                                                                                                      "epasuoraViittaus": false,
+                                                                                                      "indeksi": 2,
+                                                                                                      "vaatiiOsallistumisen": true,
+                                                                                                      "syotettavissaKaikille": true,
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      },
+                                                                                                      "syotettavanarvontyyppi": null,
+                                                                                                      "tilastoidaan": false
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "id": 558892982
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558892987
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558892986
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893075
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893074
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893093
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                      "tulosTunniste": "amm_yto_matlu_400013_1_5",
+                                                                                      "tulosTekstiFi": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–5",
+                                                                                      "tulosTekstiSv": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–5 (sv)",
+                                                                                      "tulosTekstiEn": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–5 (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [
+                                                                                        {
+                                                                                          "paluuarvo": "20",
+                                                                                          "arvo": "5",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "10",
+                                                                                          "arvo": "3",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "5",
+                                                                                          "arvo": "2",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "15",
+                                                                                          "arvo": "4",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "1",
+                                                                                          "arvo": "1",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        }
+                                                                                      ],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [
+                                                                                        {
+                                                                                          "tunniste": "400013",
+                                                                                          "kuvaus": "YTO:n Matemaattis-luonnontieteellinen osaaminen (400013) arvosanan pisteet asteikolla 1–5",
+                                                                                          "lahde": "HAETTAVA_ARVO",
+                                                                                          "onPakollinen": false,
+                                                                                          "epasuoraViittaus": false,
+                                                                                          "indeksi": 2,
+                                                                                          "vaatiiOsallistumisen": true,
+                                                                                          "syotettavissaKaikille": true,
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          },
+                                                                                          "syotettavanarvontyyppi": null,
+                                                                                          "tilastoidaan": false
+                                                                                        }
+                                                                                      ],
+                                                                                      "id": 558893083
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893094
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "0"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893090
+                                                                                    },
+                                                                                    "indeksi": 3,
+                                                                                    "id": 558893095
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893092
+                                                                              },
+                                                                              "indeksi": 3,
+                                                                              "id": 558893099
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "YHTASUURI",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "3"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893058
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893062
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "NIMETTYLUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "nimi",
+                                                                                          "arvo": "Ammatillisen yto:n matlu (400013) asteikko"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                            "tulosTunniste": "amm_yto_matlu_400013_arviointiasteikko",
+                                                                                            "tulosTekstiFi": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko",
+                                                                                            "tulosTekstiSv": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko (sv)",
+                                                                                            "tulosTekstiEn": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko (en)",
+                                                                                            "tallennaTulos": true,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [
+                                                                                              {
+                                                                                                "paluuarvo": "5",
+                                                                                                "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "paluuarvo": "3",
+                                                                                                "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              }
+                                                                                            ],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [
+                                                                                              {
+                                                                                                "tunniste": "400013",
+                                                                                                "kuvaus": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (400013) arviontiasteikko lukuarvona: 3 tai 5",
+                                                                                                "lahde": "HAETTAVA_ARVO",
+                                                                                                "onPakollinen": false,
+                                                                                                "epasuoraViittaus": false,
+                                                                                                "indeksi": 2,
+                                                                                                "vaatiiOsallistumisen": true,
+                                                                                                "syotettavissaKaikille": true,
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                },
+                                                                                                "syotettavanarvontyyppi": null,
+                                                                                                "tilastoidaan": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "id": 558892982
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558892987
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558892986
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893061
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893060
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558893097
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558893096
+                                                                        },
+                                                                        "indeksi": 2,
+                                                                        "id": 558893102
+                                                                      },
+                                                                      {
+                                                                        "funktiokutsu": {
+                                                                          "funktionimi": "JOS",
+                                                                          "tulosTunniste": null,
+                                                                          "tulosTekstiFi": null,
+                                                                          "tulosTekstiSv": null,
+                                                                          "tulosTekstiEn": null,
+                                                                          "tallennaTulos": false,
+                                                                          "omaopintopolku": false,
+                                                                          "arvokonvertteriparametrit": [],
+                                                                          "arvovalikonvertteriparametrit": [],
+                                                                          "syoteparametrit": [],
+                                                                          "funktioargumentit": [
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "YHTASUURI",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "NIMETTYLUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "nimi",
+                                                                                          "arvo": "Ammatillisen yto:n matlu (101054) asteikko"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                            "tulosTunniste": "amm_yto_matlu_101054_arviointiasteikko",
+                                                                                            "tulosTekstiFi": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko",
+                                                                                            "tulosTekstiSv": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko (sv)",
+                                                                                            "tulosTekstiEn": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko (en)",
+                                                                                            "tallennaTulos": true,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [
+                                                                                              {
+                                                                                                "paluuarvo": "5",
+                                                                                                "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "paluuarvo": "3",
+                                                                                                "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                "hylkaysperuste": "false",
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                }
+                                                                                              }
+                                                                                            ],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [
+                                                                                              {
+                                                                                                "tunniste": "101054",
+                                                                                                "kuvaus": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko",
+                                                                                                "lahde": "HAETTAVA_ARVO",
+                                                                                                "onPakollinen": false,
+                                                                                                "epasuoraViittaus": false,
+                                                                                                "indeksi": 2,
+                                                                                                "vaatiiOsallistumisen": true,
+                                                                                                "syotettavissaKaikille": true,
+                                                                                                "kuvaukset": {
+                                                                                                  "tekstit": []
+                                                                                                },
+                                                                                                "syotettavanarvontyyppi": null,
+                                                                                                "tilastoidaan": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "id": 558892972
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558892977
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558892976
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893019
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "3"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893016
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893020
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893018
+                                                                              },
+                                                                              "indeksi": 1,
+                                                                              "id": 558893055
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                "tulosTunniste": "amm_yto_matlu_101054_1_3",
+                                                                                "tulosTekstiFi": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–3",
+                                                                                "tulosTekstiSv": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–3 (sv)",
+                                                                                "tulosTekstiEn": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–3 (en)",
+                                                                                "tallennaTulos": true,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [
+                                                                                  {
+                                                                                    "paluuarvo": "13",
+                                                                                    "arvo": "2",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "2",
+                                                                                    "arvo": "1",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "paluuarvo": "20",
+                                                                                    "arvo": "3",
+                                                                                    "hylkaysperuste": "false",
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [],
+                                                                                "valintaperusteviitteet": [
+                                                                                  {
+                                                                                    "tunniste": "101054",
+                                                                                    "kuvaus": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–3",
+                                                                                    "lahde": "HAETTAVA_ARVO",
+                                                                                    "onPakollinen": false,
+                                                                                    "epasuoraViittaus": false,
+                                                                                    "indeksi": 2,
+                                                                                    "vaatiiOsallistumisen": true,
+                                                                                    "syotettavissaKaikille": true,
+                                                                                    "kuvaukset": {
+                                                                                      "tekstit": []
+                                                                                    },
+                                                                                    "syotettavanarvontyyppi": null,
+                                                                                    "tilastoidaan": false
+                                                                                  }
+                                                                                ],
+                                                                                "id": 558893025
+                                                                              },
+                                                                              "indeksi": 2,
+                                                                              "id": 558893056
+                                                                            },
+                                                                            {
+                                                                              "funktiokutsu": {
+                                                                                "funktionimi": "JOS",
+                                                                                "tulosTunniste": null,
+                                                                                "tulosTekstiFi": null,
+                                                                                "tulosTekstiSv": null,
+                                                                                "tulosTekstiEn": null,
+                                                                                "tallennaTulos": false,
+                                                                                "omaopintopolku": false,
+                                                                                "arvokonvertteriparametrit": [],
+                                                                                "arvovalikonvertteriparametrit": [],
+                                                                                "syoteparametrit": [],
+                                                                                "funktioargumentit": [
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "YHTASUURI",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "NIMETTYLUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "nimi",
+                                                                                                "arvo": "Ammatillisen yto:n matlu (101054) asteikko"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [
+                                                                                              {
+                                                                                                "funktiokutsu": {
+                                                                                                  "funktionimi": "HAEAMMATILLINENYTOARVIOINTIASTEIKKO",
+                                                                                                  "tulosTunniste": "amm_yto_matlu_101054_arviointiasteikko",
+                                                                                                  "tulosTekstiFi": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko",
+                                                                                                  "tulosTekstiSv": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko (sv)",
+                                                                                                  "tulosTekstiEn": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko (en)",
+                                                                                                  "tallennaTulos": true,
+                                                                                                  "omaopintopolku": false,
+                                                                                                  "arvokonvertteriparametrit": [
+                                                                                                    {
+                                                                                                      "paluuarvo": "3",
+                                                                                                      "arvo": "arviointiasteikkoammatillinent1k3",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "paluuarvo": "5",
+                                                                                                      "arvo": "arviointiasteikkoammatillinen15",
+                                                                                                      "hylkaysperuste": "false",
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "arvovalikonvertteriparametrit": [],
+                                                                                                  "syoteparametrit": [],
+                                                                                                  "funktioargumentit": [],
+                                                                                                  "valintaperusteviitteet": [
+                                                                                                    {
+                                                                                                      "tunniste": "101054",
+                                                                                                      "kuvaus": "Ammatillisen yto:n Matemaattis-luonnontieteellinen osaaminen (101054) arviointiasteikko",
+                                                                                                      "lahde": "HAETTAVA_ARVO",
+                                                                                                      "onPakollinen": false,
+                                                                                                      "epasuoraViittaus": false,
+                                                                                                      "indeksi": 2,
+                                                                                                      "vaatiiOsallistumisen": true,
+                                                                                                      "syotettavissaKaikille": true,
+                                                                                                      "kuvaukset": {
+                                                                                                        "tekstit": []
+                                                                                                      },
+                                                                                                      "syotettavanarvontyyppi": null,
+                                                                                                      "tilastoidaan": false
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "id": 558892972
+                                                                                                },
+                                                                                                "indeksi": 1,
+                                                                                                "id": 558892977
+                                                                                              }
+                                                                                            ],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558892976
+                                                                                          },
+                                                                                          "indeksi": 1,
+                                                                                          "id": 558893033
+                                                                                        },
+                                                                                        {
+                                                                                          "funktiokutsu": {
+                                                                                            "funktionimi": "LUKUARVO",
+                                                                                            "tulosTunniste": null,
+                                                                                            "tulosTekstiFi": null,
+                                                                                            "tulosTekstiSv": null,
+                                                                                            "tulosTekstiEn": null,
+                                                                                            "tallennaTulos": false,
+                                                                                            "omaopintopolku": false,
+                                                                                            "arvokonvertteriparametrit": [],
+                                                                                            "arvovalikonvertteriparametrit": [],
+                                                                                            "syoteparametrit": [
+                                                                                              {
+                                                                                                "avain": "luku",
+                                                                                                "arvo": "5"
+                                                                                              }
+                                                                                            ],
+                                                                                            "funktioargumentit": [],
+                                                                                            "valintaperusteviitteet": [],
+                                                                                            "id": 558893030
+                                                                                          },
+                                                                                          "indeksi": 2,
+                                                                                          "id": 558893034
+                                                                                        }
+                                                                                      ],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893032
+                                                                                    },
+                                                                                    "indeksi": 1,
+                                                                                    "id": 558893051
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "LUKUARVO",
+                                                                                      "tulosTunniste": null,
+                                                                                      "tulosTekstiFi": null,
+                                                                                      "tulosTekstiSv": null,
+                                                                                      "tulosTekstiEn": null,
+                                                                                      "tallennaTulos": false,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [
+                                                                                        {
+                                                                                          "avain": "luku",
+                                                                                          "arvo": "0"
+                                                                                        }
+                                                                                      ],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [],
+                                                                                      "id": 558893048
+                                                                                    },
+                                                                                    "indeksi": 3,
+                                                                                    "id": 558893053
+                                                                                  },
+                                                                                  {
+                                                                                    "funktiokutsu": {
+                                                                                      "funktionimi": "HAEAMMATILLINENYTOARVOSANA",
+                                                                                      "tulosTunniste": "amm_yto_matlu_101054_1_5",
+                                                                                      "tulosTekstiFi": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–5",
+                                                                                      "tulosTekstiSv": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–5 (sv)",
+                                                                                      "tulosTekstiEn": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–5 (en)",
+                                                                                      "tallennaTulos": true,
+                                                                                      "omaopintopolku": false,
+                                                                                      "arvokonvertteriparametrit": [
+                                                                                        {
+                                                                                          "paluuarvo": "1",
+                                                                                          "arvo": "1",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "5",
+                                                                                          "arvo": "2",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "10",
+                                                                                          "arvo": "3",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "15",
+                                                                                          "arvo": "4",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "paluuarvo": "20",
+                                                                                          "arvo": "5",
+                                                                                          "hylkaysperuste": "false",
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          }
+                                                                                        }
+                                                                                      ],
+                                                                                      "arvovalikonvertteriparametrit": [],
+                                                                                      "syoteparametrit": [],
+                                                                                      "funktioargumentit": [],
+                                                                                      "valintaperusteviitteet": [
+                                                                                        {
+                                                                                          "tunniste": "101054",
+                                                                                          "kuvaus": "YTO:n \"Matemaattis-luonnontieteellinen osaaminen\" (101054) pisteet asteikolta 1–5",
+                                                                                          "lahde": "HAETTAVA_ARVO",
+                                                                                          "onPakollinen": false,
+                                                                                          "epasuoraViittaus": false,
+                                                                                          "indeksi": 2,
+                                                                                          "vaatiiOsallistumisen": true,
+                                                                                          "syotettavissaKaikille": true,
+                                                                                          "kuvaukset": {
+                                                                                            "tekstit": []
+                                                                                          },
+                                                                                          "syotettavanarvontyyppi": null,
+                                                                                          "tilastoidaan": false
+                                                                                        }
+                                                                                      ],
+                                                                                      "id": 558893041
+                                                                                    },
+                                                                                    "indeksi": 2,
+                                                                                    "id": 558893052
+                                                                                  }
+                                                                                ],
+                                                                                "valintaperusteviitteet": [],
+                                                                                "id": 558893050
+                                                                              },
+                                                                              "indeksi": 3,
+                                                                              "id": 558893057
+                                                                            }
+                                                                          ],
+                                                                          "valintaperusteviitteet": [],
+                                                                          "id": 558893054
+                                                                        },
+                                                                        "indeksi": 1,
+                                                                        "id": 558893101
+                                                                      }
+                                                                    ],
+                                                                    "valintaperusteviitteet": [],
+                                                                    "id": 558893100
+                                                                  },
+                                                                  "indeksi": 1,
+                                                                  "id": 558893104
+                                                                }
+                                                              ],
+                                                              "valintaperusteviitteet": [],
+                                                              "id": 558893103
+                                                            },
+                                                            "indeksi": 2,
+                                                            "id": 558894195
+                                                          }
+                                                        ],
+                                                        "valintaperusteviitteet": [],
+                                                        "id": 558894193
+                                                      },
+                                                      "indeksi": 1,
+                                                      "id": 558894198
+                                                    }
+                                                  ],
+                                                  "valintaperusteviitteet": [],
+                                                  "id": 558894197
+                                                },
+                                                "indeksi": 1,
+                                                "id": 558893526
+                                              }
+                                            ],
+                                            "valintaperusteviitteet": [],
+                                            "id": 558893525
+                                          },
+                                          "indeksi": 1,
+                                          "id": 558893530
+                                        }
+                                      ],
+                                      "valintaperusteviitteet": [],
+                                      "id": 558893529
+                                    },
+                                    "indeksi": 2,
+                                    "id": 560516003
+                                  },
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "YHTASUURI",
+                                      "tulosTunniste": null,
+                                      "tulosTekstiFi": null,
+                                      "tulosTekstiSv": null,
+                                      "tulosTekstiEn": null,
+                                      "tallennaTulos": false,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [],
+                                      "funktioargumentit": [
+                                        {
+                                          "funktiokutsu": {
+                                            "funktionimi": "LUKUARVO",
+                                            "tulosTunniste": null,
+                                            "tulosTekstiFi": null,
+                                            "tulosTekstiSv": null,
+                                            "tulosTekstiEn": null,
+                                            "tallennaTulos": false,
+                                            "omaopintopolku": false,
+                                            "arvokonvertteriparametrit": [],
+                                            "arvovalikonvertteriparametrit": [],
+                                            "syoteparametrit": [
+                                              {
+                                                "avain": "luku",
+                                                "arvo": "2015"
+                                              }
+                                            ],
+                                            "funktioargumentit": [],
+                                            "valintaperusteviitteet": [],
+                                            "id": 560515985
+                                          },
+                                          "indeksi": 2,
+                                          "id": 560515989
+                                        },
+                                        {
+                                          "funktiokutsu": {
+                                            "funktionimi": "NIMETTYLUKUARVO",
+                                            "tulosTunniste": null,
+                                            "tulosTekstiFi": null,
+                                            "tulosTekstiSv": null,
+                                            "tulosTekstiEn": null,
+                                            "tallennaTulos": false,
+                                            "omaopintopolku": false,
+                                            "arvokonvertteriparametrit": [],
+                                            "arvovalikonvertteriparametrit": [],
+                                            "syoteparametrit": [
+                                              {
+                                                "avain": "nimi",
+                                                "arvo": "Ammatillisen perustutkinnon suoritustapa"
+                                              }
+                                            ],
+                                            "funktioargumentit": [
+                                              {
+                                                "funktiokutsu": {
+                                                  "funktionimi": "NIMETTYLUKUARVO",
+                                                  "tulosTunniste": "amm_tutkinnon_suoritustapa",
+                                                  "tulosTekstiFi": "Ammatillisen perustutkinnon suoritustapa",
+                                                  "tulosTekstiSv": "Ammatillisen perustutkinnon suoritustapa (sv)",
+                                                  "tulosTekstiEn": "Ammatillisen perustutkinnon suoritustapa (en)",
+                                                  "tallennaTulos": true,
+                                                  "omaopintopolku": true,
+                                                  "arvokonvertteriparametrit": [],
+                                                  "arvovalikonvertteriparametrit": [],
+                                                  "syoteparametrit": [
+                                                    {
+                                                      "avain": "nimi",
+                                                      "arvo": "Ammatillisen perustutkinnon suoritustapa"
+                                                    }
+                                                  ],
+                                                  "funktioargumentit": [
+                                                    {
+                                                      "funktiokutsu": {
+                                                        "funktionimi": "HAEAMMATILLISENTUTKINNONSUORITUSTAPA",
+                                                        "tulosTunniste": "amm_tutkinnon_suoritustapa",
+                                                        "tulosTekstiFi": "Ammatillisen perustutkinnon suoritustapa (ops / reformi) lukuarvoksi (2015 / 2017)",
+                                                        "tulosTekstiSv": "Ammatillisen perustutkinnon suoritustapa (ops / reformi) lukuarvoksi (2015 / 2017) (sv)",
+                                                        "tulosTekstiEn": "Ammatillisen perustutkinnon suoritustapa (ops / reformi) lukuarvoksi (2015 / 2017) (en)",
+                                                        "tallennaTulos": true,
+                                                        "omaopintopolku": true,
+                                                        "arvokonvertteriparametrit": [
+                                                          {
+                                                            "paluuarvo": "2015",
+                                                            "arvo": "ops",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          },
+                                                          {
+                                                            "paluuarvo": "2017",
+                                                            "arvo": "reformi",
+                                                            "hylkaysperuste": "false",
+                                                            "kuvaukset": {
+                                                              "tekstit": []
+                                                            }
+                                                          }
+                                                        ],
+                                                        "arvovalikonvertteriparametrit": [],
+                                                        "syoteparametrit": [],
+                                                        "funktioargumentit": [],
+                                                        "valintaperusteviitteet": [],
+                                                        "id": 558893399
+                                                      },
+                                                      "indeksi": 1,
+                                                      "id": 558893403
+                                                    }
+                                                  ],
+                                                  "valintaperusteviitteet": [],
+                                                  "id": 558893402
+                                                },
+                                                "indeksi": 1,
+                                                "id": 558893406
+                                              }
+                                            ],
+                                            "valintaperusteviitteet": [],
+                                            "id": 558893405
+                                          },
+                                          "indeksi": 1,
+                                          "id": 560515988
+                                        }
+                                      ],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560515987
+                                    },
+                                    "indeksi": 1,
+                                    "id": 560516002
+                                  }
+                                ],
+                                "valintaperusteviitteet": [],
+                                "id": 560516001
+                              },
+                              "indeksi": 1,
+                              "id": 560516028
+                            },
+                            {
+                              "funktiokutsu": {
+                                "funktionimi": "JOS",
+                                "tulosTunniste": "laiskajos",
+                                "tulosTekstiFi": "laiskajos",
+                                "tulosTekstiSv": "laiskajos",
+                                "tulosTekstiEn": "laiskajos",
+                                "tallennaTulos": true,
+                                "omaopintopolku": false,
+                                "arvokonvertteriparametrit": [],
+                                "arvovalikonvertteriparametrit": [],
+                                "syoteparametrit": [
+                                  {
+                                    "avain": "laskeLaiskasti",
+                                    "arvo": "true"
+                                  }
+                                ],
+                                "funktioargumentit": [
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "TOTUUSARVO",
+                                      "tulosTunniste": "laiskajos-tosi",
+                                      "tulosTekstiFi": "laiskajos-tosi",
+                                      "tulosTekstiSv": "laiskajos-tosi",
+                                      "tulosTekstiEn": "laiskajos-tosi",
+                                      "tallennaTulos": true,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [
+                                        {
+                                          "avain": "totuusarvo",
+                                          "arvo": "true"
+                                        }
+                                      ],
+                                      "funktioargumentit": [],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560516005
+                                    },
+                                    "indeksi": 1,
+                                    "id": 560516012
+                                  },
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "LUKUARVO",
+                                      "tulosTunniste": "laiska_-2",
+                                      "tulosTekstiFi": null,
+                                      "tulosTekstiSv": null,
+                                      "tulosTekstiEn": null,
+                                      "tallennaTulos": true,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [
+                                        {
+                                          "avain": "luku",
+                                          "arvo": "-2"
+                                        }
+                                      ],
+                                      "funktioargumentit": [],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560516009
+                                    },
+                                    "indeksi": 3,
+                                    "id": 560516014
+                                  },
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "LUKUARVO",
+                                      "tulosTunniste": "laiska_-1",
+                                      "tulosTekstiFi": "laiska_-1",
+                                      "tulosTekstiSv": "laiska_-1",
+                                      "tulosTekstiEn": "laiska_-1",
+                                      "tallennaTulos": true,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [
+                                        {
+                                          "avain": "luku",
+                                          "arvo": "-1"
+                                        }
+                                      ],
+                                      "funktioargumentit": [],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560516007
+                                    },
+                                    "indeksi": 2,
+                                    "id": 560516013
+                                  }
+                                ],
+                                "valintaperusteviitteet": [],
+                                "id": 560516011
+                              },
+                              "indeksi": 2,
+                              "id": 560516029
+                            },
+                            {
+                              "funktiokutsu": {
+                                "funktionimi": "JOS",
+                                "tulosTunniste": "ahnejos",
+                                "tulosTekstiFi": "ahnejos",
+                                "tulosTekstiSv": "ahnejos",
+                                "tulosTekstiEn": "ahnejos",
+                                "tallennaTulos": true,
+                                "omaopintopolku": false,
+                                "arvokonvertteriparametrit": [],
+                                "arvovalikonvertteriparametrit": [],
+                                "syoteparametrit": [
+                                  {
+                                    "avain": "laskeLaiskasti",
+                                    "arvo": ""
+                                  }
+                                ],
+                                "funktioargumentit": [
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "LUKUARVO",
+                                      "tulosTunniste": "ahne_-200",
+                                      "tulosTekstiFi": "ahne_-200",
+                                      "tulosTekstiSv": "ahne_-200",
+                                      "tulosTekstiEn": "ahne_-200",
+                                      "tallennaTulos": true,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [
+                                        {
+                                          "avain": "luku",
+                                          "arvo": "-200"
+                                        }
+                                      ],
+                                      "funktioargumentit": [],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560516020
+                                    },
+                                    "indeksi": 3,
+                                    "id": 560516025
+                                  },
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "TOTUUSARVO",
+                                      "tulosTunniste": "eagerjos-tosi",
+                                      "tulosTekstiFi": "eagerjos-tosi",
+                                      "tulosTekstiSv": "eagerjos-tosi",
+                                      "tulosTekstiEn": "eagerjos-tosi",
+                                      "tallennaTulos": true,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [
+                                        {
+                                          "avain": "totuusarvo",
+                                          "arvo": "true"
+                                        }
+                                      ],
+                                      "funktioargumentit": [],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560516016
+                                    },
+                                    "indeksi": 1,
+                                    "id": 560516023
+                                  },
+                                  {
+                                    "funktiokutsu": {
+                                      "funktionimi": "LUKUARVO",
+                                      "tulosTunniste": "ahne_-100",
+                                      "tulosTekstiFi": "ahne_-100",
+                                      "tulosTekstiSv": "ahne_-100",
+                                      "tulosTekstiEn": "ahne_-100",
+                                      "tallennaTulos": true,
+                                      "omaopintopolku": false,
+                                      "arvokonvertteriparametrit": [],
+                                      "arvovalikonvertteriparametrit": [],
+                                      "syoteparametrit": [
+                                        {
+                                          "avain": "luku",
+                                          "arvo": "-100"
+                                        }
+                                      ],
+                                      "funktioargumentit": [],
+                                      "valintaperusteviitteet": [],
+                                      "id": 560516018
+                                    },
+                                    "indeksi": 2,
+                                    "id": 560516024
+                                  }
+                                ],
+                                "valintaperusteviitteet": [],
+                                "id": 560516022
+                              },
+                              "indeksi": 3,
+                              "id": 560516030
+                            }
+                          ],
+                          "valintaperusteviitteet": [],
+                          "id": 560516027
+                        },
+                        "indeksi": 1,
+                        "id": 560516032
+                      }
+                    ],
+                    "valintaperusteviitteet": [],
+                    "id": 560516031
                   },
                   "indeksi": 1,
-                  "id": 481912250
+                  "id": 560516036
                 }
               ],
               "valintaperusteviitteet": [],
-              "id": 481912249
+              "id": 560516035
             }
           }
         ],
@@ -81,11 +6455,7 @@
         "poistetaankoHylatyt": false
       }
     ],
-    "valintakoe": [],
-    "nimi": "Varsinainen valinta",
-    "aktiivinen": true,
-    "valinnanVaiheTyyppi": "TAVALLINEN"
+    "valintakoe": []
   },
   "hakukohteenValintaperuste": []
 }
-

--- a/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/koski-monitutkinto.json
+++ b/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/koski-monitutkinto.json
@@ -1,0 +1,753 @@
+[
+     {
+       "oid": "1.2.246.562.15.32702385413",
+       "versionumero": 3,
+       "aikaleima": "2018-04-12T13:51:30.973557",
+       "lähdejärjestelmänId": {
+         "id": "2772",
+         "lähdejärjestelmä": {
+           "koodiarvo": "primus",
+           "nimi": {
+             "fi": "primus"
+           },
+           "koodistoUri": "lahdejarjestelma",
+           "koodistoVersio": 1
+         }
+       },
+       "oppilaitos": {
+         "oid": "1.2.246.562.10.98806593921",
+         "oppilaitosnumero": {
+           "koodiarvo": "42832",
+           "nimi": {
+             "fi": "Äyhtävän superopisto",
+             "sv": "Äyhtävän superopisto",
+             "en": "Äyhtävän superopisto"
+           },
+           "lyhytNimi": {
+             "fi": "Äyhtävän superop."
+           },
+           "koodistoUri": "oppilaitosnumero",
+           "koodistoVersio": 1
+         },
+         "nimi": {
+           "fi": "Äyhtävän superopisto",
+           "sv": "Äyhtävän superopisto",
+           "en": "Äyhtävän superopisto"
+         },
+         "kotipaikka": {
+           "koodiarvo": "999",
+           "nimi": {
+             "fi": "Äyhtävä",
+             "sv": "Äyhtävä"
+           },
+           "koodistoUri": "kunta",
+           "koodistoVersio": 2
+         }
+       },
+       "koulutustoimija": {
+         "oid": "1.2.246.562.10.83681839128",
+         "nimi": {
+           "fi": "Äyhtävän kunta"
+         },
+         "yTunnus": "7145612-8",
+         "kotipaikka": {
+           "koodiarvo": "997",
+           "nimi": {
+             "fi": "Äyhtävä",
+             "sv": "Äyhtävä"
+           },
+           "koodistoUri": "kunta",
+           "koodistoVersio": 2
+         }
+       },
+       "arvioituPäättymispäivä": "2017-12-19",
+       "ostettu": false,
+       "tila": {
+         "opiskeluoikeusjaksot": [
+           {
+             "alku": "2016-01-07",
+             "tila": {
+               "koodiarvo": "lasna",
+               "nimi": {
+                 "fi": "Läsnä",
+                 "sv": "Närvarande"
+               },
+               "koodistoUri": "koskiopiskeluoikeudentila",
+               "koodistoVersio": 1
+             },
+             "opintojenRahoitus": {
+               "koodiarvo": "1",
+               "nimi": {
+                 "fi": "Valtionosuusrahoitteinen koulutus",
+                 "sv": "Statsandelsfinansierad utbildning"
+               },
+               "koodistoUri": "opintojenrahoitus",
+               "koodistoVersio": 1
+             }
+           },
+           {
+             "alku": "2017-12-19",
+             "tila": {
+               "koodiarvo": "valmistunut",
+               "nimi": {
+                 "fi": "Valmistunut",
+                 "sv": "Utexaminerad"
+               },
+               "koodistoUri": "koskiopiskeluoikeudentila",
+               "koodistoVersio": 1
+             }
+           }
+         ]
+       },
+       "suoritukset": [
+         {
+           "koulutusmoduuli": {
+             "tunniste": {
+               "koodiarvo": "321602",
+               "nimi": {
+                 "fi": "Audiovisuaalisen viestinnän perustutkinto",
+                 "sv": "Grundexamen i audiovisuell kommunikation",
+                 "en": "Audiovisual Communication, VQ"
+               },
+               "lyhytNimi": {
+                 "fi": "Audiovis. viestinnän perustutk",
+                 "sv": "Grundexamen i audiovisuell kommunikation",
+                 "en": "Audiovisual Communication, Vocational Qualification"
+               },
+               "koodistoUri": "koulutus",
+               "koodistoVersio": 9
+             },
+             "perusteenDiaarinumero": "38/011/2014",
+             "koulutustyyppi": {
+               "koodiarvo": "1",
+               "nimi": {
+                 "fi": "Ammatillinen perustutkinto",
+                 "sv": "Yrkesinriktad grundexamen"
+               },
+               "lyhytNimi": {
+                 "fi": "Ammatillinen perustutkinto",
+                 "sv": "Yrkesinriktad grundexamen"
+               },
+               "koodistoUri": "koulutustyyppi",
+               "koodistoVersio": 2
+             }
+           },
+           "suoritustapa": {
+             "koodiarvo": "ops",
+             "nimi": {
+               "fi": "Ammatillinen perustutkinto",
+               "sv": "Läroplansbaserad",
+               "en": "Opetussuunnitelman mukainen"
+             },
+             "lyhytNimi": {
+               "fi": "ops",
+               "sv": "ops",
+               "en": "ops"
+             },
+             "koodistoUri": "ammatillisentutkinnonsuoritustapa",
+             "koodistoVersio": 1
+           },
+           "tutkintonimike": [
+             {
+               "koodiarvo": "10092",
+               "nimi": {
+                 "fi": "Media-assistentti",
+                 "sv": "Medieassistent"
+               },
+               "lyhytNimi": {
+                 "fi": "Media-assistentti",
+                 "sv": "Medieassistent"
+               },
+               "koodistoUri": "tutkintonimikkeet",
+               "koodistoVersio": 2
+             }
+           ],
+           "toimipiste": {
+             "oid": "1.2.246.562.10.98806593921",
+             "oppilaitosnumero": {
+               "koodiarvo": "42832",
+               "nimi": {
+                 "fi": "Äyhtävän superopisto",
+                 "sv": "Äyhtävän superopisto",
+                 "en": "Äyhtävän superopisto"
+               },
+               "lyhytNimi": {
+                 "fi": "Äyhtävän superop."
+               },
+               "koodistoUri": "oppilaitosnumero",
+               "koodistoVersio": 1
+             },
+             "nimi": {
+               "fi": "Äyhtävän superopisto",
+               "sv": "Äyhtävän superopisto",
+               "en": "Äyhtävän superopisto"
+             },
+             "kotipaikka": {
+               "koodiarvo": "749",
+               "nimi": {
+                 "fi": "Äyhtävä",
+                 "sv": "Äyhtävä"
+               },
+               "koodistoUri": "kunta",
+               "koodistoVersio": 2
+             }
+           },
+           "alkamispäivä": "2016-01-07",
+           "vahvistus": {
+             "päivä": "2017-12-19",
+             "paikkakunta": {
+               "koodiarvo": "749",
+               "nimi": {
+                 "fi": "Äyhtävä",
+                 "sv": "Äyhtävä"
+               },
+               "koodistoUri": "kunta",
+               "koodistoVersio": 2
+             },
+             "myöntäjäOrganisaatio": {
+               "oid": "1.2.246.562.10.98806593921",
+               "oppilaitosnumero": {
+                 "koodiarvo": "42832",
+                 "nimi": {
+                   "fi": "Äyhtävän superopisto",
+                   "sv": "Äyhtävän superopisto",
+                   "en": "Äyhtävän superopisto"
+                 },
+                 "lyhytNimi": {
+                   "fi": "Äyhtävän superop."
+                 },
+                 "koodistoUri": "oppilaitosnumero",
+                 "koodistoVersio": 1
+               },
+               "nimi": {
+                 "fi": "Äyhtävän superopisto",
+                 "sv": "Äyhtävän superopisto",
+                 "en": "Äyhtävän superopisto"
+               },
+               "kotipaikka": {
+                 "koodiarvo": "749",
+                 "nimi": {
+                   "fi": "Äyhtävä",
+                   "sv": "Äyhtävä"
+                 },
+                 "koodistoUri": "kunta",
+                 "koodistoVersio": 2
+               }
+             },
+             "myöntäjäHenkilöt": [
+               {
+                 "nimi": "Daisy Arrows",
+                 "titteli": {
+                   "fi": "Rehtori"
+                 },
+                 "organisaatio": {
+                   "oid": "1.2.246.562.10.98806593921",
+                   "oppilaitosnumero": {
+                     "koodiarvo": "42832",
+                     "nimi": {
+                       "fi": "Äyhtävän superopisto",
+                       "sv": "Äyhtävän superopisto",
+                       "en": "Äyhtävän superopisto"
+                     },
+                     "lyhytNimi": {
+                       "fi": "Äyhtävän superop."
+                     },
+                     "koodistoUri": "oppilaitosnumero",
+                     "koodistoVersio": 1
+                   },
+                   "nimi": {
+                     "fi": "Äyhtävän superopisto",
+                     "sv": "Äyhtävän superopisto",
+                     "en": "Äyhtävän superopisto"
+                   },
+                   "kotipaikka": {
+                     "koodiarvo": "749",
+                     "nimi": {
+                       "fi": "Äyhtävä",
+                       "sv": "Äyhtävä"
+                     },
+                     "koodistoUri": "kunta",
+                     "koodistoVersio": 2
+                   }
+                 }
+               }
+             ]
+           },
+           "suorituskieli": {
+             "koodiarvo": "FI",
+             "nimi": {
+               "fi": "suomi",
+               "sv": "finska",
+               "en": "Finnish"
+             },
+             "lyhytNimi": {
+               "fi": "suomi",
+               "sv": "finska",
+               "en": "Finnish"
+             },
+             "koodistoUri": "kieli",
+             "koodistoVersio": 1
+           },
+           "osasuoritukset": [],
+           "tyyppi": {
+             "koodiarvo": "ammatillinentutkinto",
+             "nimi": {
+               "fi": "Ammatillinen tutkinto",
+               "sv": "Yrkesinriktad examen"
+             },
+             "koodistoUri": "suorituksentyyppi",
+             "koodistoVersio": 1
+           }
+         }
+       ],
+       "tyyppi": {
+         "koodiarvo": "ammatillinenkoulutus",
+         "nimi": {
+           "fi": "Ammatillinen koulutus",
+           "sv": "Yrkesutbildning"
+         },
+         "lyhytNimi": {
+           "fi": "Ammatillinen koulutus"
+         },
+         "koodistoUri": "opiskeluoikeudentyyppi",
+         "koodistoVersio": 1
+       },
+       "alkamispäivä": "2016-01-07",
+       "päättymispäivä": "2017-12-19"
+     },
+     {
+       "oid": "1.2.246.562.15.12442534343",
+       "versionumero": 3,
+       "aikaleima": "2019-10-08T23:10:27.540254",
+       "lähdejärjestelmänId": {
+         "id": "153903",
+         "lähdejärjestelmä": {
+           "koodiarvo": "primus",
+           "nimi": {
+             "fi": "primus"
+           },
+           "koodistoUri": "lahdejarjestelma",
+           "koodistoVersio": 1
+         }
+       },
+       "oppilaitos": {
+         "oid": "1.2.246.562.10.43432423433",
+         "oppilaitosnumero": {
+           "koodiarvo": "83712",
+           "nimi": {
+             "fi": "Äyhtävän ammattiopisto"
+           },
+           "koodistoUri": "oppilaitosnumero",
+           "koodistoVersio": 1
+         },
+         "nimi": {
+           "fi": "Äyhtävän ammattiopisto"
+         },
+         "kotipaikka": {
+           "koodiarvo": "997",
+           "nimi": {
+             "fi": "Äyhtävä",
+             "sv": "Äyhtävä"
+           },
+           "koodistoUri": "kunta",
+           "koodistoVersio": 2
+         }
+       },
+       "koulutustoimija": {
+         "oid": "1.2.246.562.10.43434243433",
+         "nimi": {
+           "fi": "Äyhtävän Koulutuskuntayhtymä"
+         },
+         "yTunnus": "0025266-2",
+         "kotipaikka": {
+           "koodiarvo": "997",
+           "nimi": {
+             "fi": "Äyhtävä",
+             "sv": "Äyhtävä"
+           },
+           "koodistoUri": "kunta",
+           "koodistoVersio": 2
+         }
+       },
+       "arvioituPäättymispäivä": "2019-08-12",
+       "ostettu": false,
+       "tila": {
+         "opiskeluoikeusjaksot": [
+           {
+             "alku": "2018-08-14",
+             "tila": {
+               "koodiarvo": "lasna",
+               "nimi": {
+                 "fi": "Läsnä",
+                 "sv": "Närvarande",
+                 "en": "Present"
+               },
+               "koodistoUri": "koskiopiskeluoikeudentila",
+               "koodistoVersio": 1
+             },
+             "opintojenRahoitus": {
+               "koodiarvo": "1",
+               "nimi": {
+                 "fi": "Valtionosuusrahoitteinen koulutus",
+                 "sv": "Statsandelsfinansierad utbildning"
+               },
+               "koodistoUri": "opintojenrahoitus",
+               "koodistoVersio": 1
+             }
+           },
+           {
+             "alku": "2019-01-01",
+             "tila": {
+               "koodiarvo": "lasna",
+               "nimi": {
+                 "fi": "Läsnä",
+                 "sv": "Närvarande",
+                 "en": "Present"
+               },
+               "koodistoUri": "koskiopiskeluoikeudentila",
+               "koodistoVersio": 1
+             },
+             "opintojenRahoitus": {
+               "koodiarvo": "1",
+               "nimi": {
+                 "fi": "Valtionosuusrahoitteinen koulutus",
+                 "sv": "Statsandelsfinansierad utbildning"
+               },
+               "koodistoUri": "opintojenrahoitus",
+               "koodistoVersio": 1
+             }
+           },
+           {
+             "alku": "2019-08-30",
+             "tila": {
+               "koodiarvo": "valmistunut",
+               "nimi": {
+                 "fi": "Valmistunut",
+                 "sv": "Utexaminerad",
+                 "en": "Graduated"
+               },
+               "koodistoUri": "koskiopiskeluoikeudentila",
+               "koodistoVersio": 1
+             },
+             "opintojenRahoitus": {
+               "koodiarvo": "1",
+               "nimi": {
+                 "fi": "Valtionosuusrahoitteinen koulutus",
+                 "sv": "Statsandelsfinansierad utbildning"
+               },
+               "koodistoUri": "opintojenrahoitus",
+               "koodistoVersio": 1
+             }
+           }
+         ]
+       },
+       "suoritukset": [
+         {
+           "koulutusmoduuli": {
+             "tunniste": {
+               "koodiarvo": "361902",
+               "nimi": {
+                 "fi": "Luonto- ja ympäristöalan perustutkinto",
+                 "sv": "Grundexamen i natur och miljö",
+                 "en": "Vocational qualification in Natural and Environmental Protection"
+               },
+               "lyhytNimi": {
+                 "fi": "Luonto- ja ympär.alan perust.",
+                 "sv": "Grundexamen i natur och miljö",
+                 "en": "Vocational qualification in Natural and Environmental Protection"
+               },
+               "koodistoUri": "koulutus",
+               "koodistoVersio": 12
+             },
+             "perusteenDiaarinumero": "OPH-2847-2017",
+             "perusteenNimi": {
+               "fi": "Luonto- ja ympäristöalan perustutkinto",
+               "sv": "Grundexamen i natur och miljö",
+               "en": "Vocational Qualification in Natural and Environmental Protection"
+             },
+             "koulutustyyppi": {
+               "koodiarvo": "1",
+               "nimi": {
+                 "fi": "Ammatillinen perustutkinto",
+                 "sv": "Yrkesinriktad grundexamen",
+                 "en": "Vocational upper secondary qualification"
+               },
+               "lyhytNimi": {
+                 "fi": "Ammatillinen perustutkinto",
+                 "sv": "Yrkesinriktad grundexamen"
+               },
+               "koodistoUri": "koulutustyyppi",
+               "koodistoVersio": 2
+             }
+           },
+           "suoritustapa": {
+             "koodiarvo": "reformi",
+             "nimi": {
+               "fi": "Reformin mukainen näyttö",
+               "sv": "Reform"
+             },
+             "lyhytNimi": {
+               "fi": "Reformi"
+             },
+             "koodistoUri": "ammatillisentutkinnonsuoritustapa",
+             "koodistoVersio": 1
+           },
+           "tutkintonimike": [
+             {
+               "koodiarvo": "10135",
+               "nimi": {
+                 "fi": "Luonto-ohjaaja",
+                 "sv": "Naturinstruktör"
+               },
+               "lyhytNimi": {
+                 "fi": "Luonto-ohjaaja",
+                 "sv": "Naturinstruktör"
+               },
+               "koodistoUri": "tutkintonimikkeet",
+               "koodistoVersio": 2
+             }
+           ],
+           "osaamisala": [
+             {
+               "osaamisala": {
+                 "koodiarvo": "1764",
+                 "nimi": {
+                   "fi": "Luontoalan osaamisala",
+                   "sv": "Kompetensområdet för natur"
+                 },
+                 "lyhytNimi": {
+                   "fi": "Luontoalan osaamisala",
+                   "sv": "Kompetensområdet för natur"
+                 },
+                 "koodistoUri": "osaamisala",
+                 "koodistoVersio": 3
+               }
+             }
+           ],
+           "toimipiste": {
+             "oid": "1.2.246.562.10.3232323233232332323222",
+             "nimi": {
+               "fi": "Äyhtävän ammattiopisto, Äyhtävä, Norsukuja 3"
+             },
+             "kotipaikka": {
+               "koodiarvo": "997",
+               "nimi": {
+                 "fi": "Äyhtävä",
+                 "sv": "Äyhtävä"
+               },
+               "koodistoUri": "kunta",
+               "koodistoVersio": 2
+             }
+           },
+           "alkamispäivä": "2018-08-14",
+           "vahvistus": {
+             "päivä": "2019-08-30",
+             "paikkakunta": {
+               "koodiarvo": "997",
+               "nimi": {
+                 "fi": "Äyhtävä",
+                 "sv": "Äyhtävä"
+               },
+               "koodistoUri": "kunta",
+               "koodistoVersio": 2
+             },
+             "myöntäjäOrganisaatio": {
+               "oid": "1.2.246.562.10.12212121222",
+               "oppilaitosnumero": {
+                 "koodiarvo": "19821",
+                 "nimi": {
+                   "fi": "Äyhtävän ammattiopisto"
+                 },
+                 "koodistoUri": "oppilaitosnumero",
+                 "koodistoVersio": 1
+               },
+               "nimi": {
+                 "fi": "Äyhtävän ammattiopisto"
+               },
+               "kotipaikka": {
+                 "koodiarvo": "997",
+                 "nimi": {
+                   "fi": "Äyhtävä",
+                   "sv": "Äyhtävä"
+                 },
+                 "koodistoUri": "kunta",
+                 "koodistoVersio": 2
+               }
+             },
+             "myöntäjäHenkilöt": [
+               {
+                 "nimi": "Frank Johtaja",
+                 "titteli": {
+                   "fi": "Tirehtööri"
+                 },
+                 "organisaatio": {
+                   "oid": "1.2.246.562.10.11122132323",
+                   "oppilaitosnumero": {
+                     "koodiarvo": "32322",
+                     "nimi": {
+                       "fi": "Äyhtävän ammattiopisto"
+                     },
+                     "koodistoUri": "oppilaitosnumero",
+                     "koodistoVersio": 1
+                   },
+                   "nimi": {
+                     "fi": "Äyhtävän ammattiopisto"
+                   },
+                   "kotipaikka": {
+                     "koodiarvo": "999",
+                     "nimi": {
+                       "fi": "Äyhtävä",
+                       "sv": "Äyhtävä"
+                     },
+                     "koodistoUri": "kunta",
+                     "koodistoVersio": 2
+                   }
+                 }
+               }
+             ]
+           },
+           "suorituskieli": {
+             "koodiarvo": "FI",
+             "nimi": {
+               "fi": "suomi",
+               "sv": "finska",
+               "en": "Finnish"
+             },
+             "lyhytNimi": {
+               "fi": "suomi",
+               "sv": "finska",
+               "en": "Finnish"
+             },
+             "koodistoUri": "kieli",
+             "koodistoVersio": 1
+           },
+           "osaamisenHankkimistavat": [
+             {
+               "alku": "2018-12-10",
+               "loppu": "2018-12-31",
+               "osaamisenHankkimistapa": {
+                 "tunniste": {
+                   "koodiarvo": "koulutussopimus",
+                   "nimi": {
+                     "fi": "Koulutussopimus",
+                     "sv": "Utbildningsavtal"
+                   },
+                   "koodistoUri": "osaamisenhankkimistapa",
+                   "koodistoVersio": 1
+                 }
+               }
+             },
+             {
+               "alku": "2019-06-03",
+               "loppu": "2019-07-12",
+               "osaamisenHankkimistapa": {
+                 "tunniste": {
+                   "koodiarvo": "koulutussopimus",
+                   "nimi": {
+                     "fi": "Koulutussopimus",
+                     "sv": "Utbildningsavtal"
+                   },
+                   "koodistoUri": "osaamisenhankkimistapa",
+                   "koodistoVersio": 1
+                 }
+               }
+             }
+           ],
+           "koulutussopimukset": [
+             {
+               "alku": "2018-12-10",
+               "loppu": "2018-12-31",
+               "työssäoppimispaikka": {
+                 "fi": "Yksityinen asiakaskohde"
+               },
+               "paikkakunta": {
+                 "koodiarvo": "997",
+                 "nimi": {
+                   "fi": "Äyhtävä",
+                   "sv": "Äyhtävä"
+                 },
+                 "koodistoUri": "kunta",
+                 "koodistoVersio": 2
+               },
+               "maa": {
+                 "koodiarvo": "246",
+                 "nimi": {
+                   "fi": "Suomi",
+                   "sv": "Finland",
+                   "en": "Finland"
+                 },
+                 "lyhytNimi": {
+                   "fi": "FI",
+                   "sv": "FI",
+                   "en": "FI"
+                 },
+                 "koodistoUri": "maatjavaltiot2",
+                 "koodistoVersio": 2
+               }
+             },
+             {
+               "alku": "2019-06-03",
+               "loppu": "2019-07-12",
+               "työssäoppimispaikka": {
+                 "fi": "Yksityinen asiakaskohde"
+               },
+               "paikkakunta": {
+                 "koodiarvo": "997",
+                 "nimi": {
+                   "fi": "Äyhtävä",
+                   "sv": "Äyhtävä"
+                 },
+                 "koodistoUri": "kunta",
+                 "koodistoVersio": 2
+               },
+               "maa": {
+                 "koodiarvo": "246",
+                 "nimi": {
+                   "fi": "Suomi",
+                   "sv": "Finland",
+                   "en": "Finland"
+                 },
+                 "lyhytNimi": {
+                   "fi": "FI",
+                   "sv": "FI",
+                   "en": "FI"
+                 },
+                 "koodistoUri": "maatjavaltiot2",
+                 "koodistoVersio": 2
+               }
+             }
+           ],
+           "osasuoritukset": [],
+           "tyyppi": {
+             "koodiarvo": "ammatillinentutkinto",
+             "nimi": {
+               "fi": "Ammatillinen tutkinto",
+               "sv": "Yrkesinriktad examen",
+               "en": "Vocational education  qualification"
+             },
+             "koodistoUri": "suorituksentyyppi",
+             "koodistoVersio": 1
+           }
+         }
+       ],
+       "lisätiedot": {
+         "oikeusMaksuttomaanAsuntolapaikkaan": true,
+         "henkilöstökoulutus": false,
+         "koulutusvienti": false
+       },
+       "tyyppi": {
+         "koodiarvo": "ammatillinenkoulutus",
+         "nimi": {
+           "fi": "Ammatillinen koulutus",
+           "sv": "Yrkesutbildning"
+         },
+         "lyhytNimi": {
+           "fi": "Ammatillinen koulutus"
+         },
+         "koodistoUri": "opiskeluoikeudentyyppi",
+         "koodistoVersio": 1
+       },
+       "alkamispäivä": "2018-08-14",
+       "päättymispäivä": "2019-08-30"
+     }
+   ]

--- a/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-01.json
+++ b/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-01.json
@@ -1,0 +1,435 @@
+{
+  "oid": "1.2.246.562.15.12442534343",
+  "versionumero": 1,
+  "aikaleima": "2019-10-01T20:10:27.540254",
+  "lähdejärjestelmänId": {
+    "id": "153903",
+    "lähdejärjestelmä": {
+      "koodiarvo": "primus",
+      "nimi": {
+        "fi": "primus"
+      },
+      "koodistoUri": "lahdejarjestelma",
+      "koodistoVersio": 1
+    }
+  },
+  "oppilaitos": {
+    "oid": "1.2.246.562.10.43432423433",
+    "oppilaitosnumero": {
+      "koodiarvo": "83712",
+      "nimi": {
+        "fi": "Äyhtävän ammattiopisto"
+      },
+      "koodistoUri": "oppilaitosnumero",
+      "koodistoVersio": 1
+    },
+    "nimi": {
+      "fi": "Äyhtävän ammattiopisto"
+    },
+    "kotipaikka": {
+      "koodiarvo": "997",
+      "nimi": {
+        "fi": "Äyhtävä",
+        "sv": "Äyhtävä"
+      },
+      "koodistoUri": "kunta",
+      "koodistoVersio": 2
+    }
+  },
+  "koulutustoimija": {
+    "oid": "1.2.246.562.10.43434243433",
+    "nimi": {
+      "fi": "Äyhtävän Koulutuskuntayhtymä"
+    },
+    "yTunnus": "0025266-2",
+    "kotipaikka": {
+      "koodiarvo": "997",
+      "nimi": {
+        "fi": "Äyhtävä",
+        "sv": "Äyhtävä"
+      },
+      "koodistoUri": "kunta",
+      "koodistoVersio": 2
+    }
+  },
+  "arvioituPäättymispäivä": "2019-08-12",
+  "ostettu": false,
+  "tila": {
+    "opiskeluoikeusjaksot": [
+      {
+        "alku": "2018-08-14",
+        "tila": {
+          "koodiarvo": "lasna",
+          "nimi": {
+            "fi": "Läsnä",
+            "sv": "Närvarande",
+            "en": "Present"
+          },
+          "koodistoUri": "koskiopiskeluoikeudentila",
+          "koodistoVersio": 1
+        },
+        "opintojenRahoitus": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Valtionosuusrahoitteinen koulutus",
+            "sv": "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri": "opintojenrahoitus",
+          "koodistoVersio": 1
+        }
+      },
+      {
+        "alku": "2019-01-01",
+        "tila": {
+          "koodiarvo": "lasna",
+          "nimi": {
+            "fi": "Läsnä",
+            "sv": "Närvarande",
+            "en": "Present"
+          },
+          "koodistoUri": "koskiopiskeluoikeudentila",
+          "koodistoVersio": 1
+        },
+        "opintojenRahoitus": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Valtionosuusrahoitteinen koulutus",
+            "sv": "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri": "opintojenrahoitus",
+          "koodistoVersio": 1
+        }
+      },
+      {
+        "alku": "2019-08-30",
+        "tila": {
+          "koodiarvo": "valmistunut",
+          "nimi": {
+            "fi": "Valmistunut",
+            "sv": "Utexaminerad",
+            "en": "Graduated"
+          },
+          "koodistoUri": "koskiopiskeluoikeudentila",
+          "koodistoVersio": 1
+        },
+        "opintojenRahoitus": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Valtionosuusrahoitteinen koulutus",
+            "sv": "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri": "opintojenrahoitus",
+          "koodistoVersio": 1
+        }
+      }
+    ]
+  },
+  "suoritukset": [
+    {
+      "koulutusmoduuli": {
+        "tunniste": {
+          "koodiarvo": "361902",
+          "nimi": {
+            "fi": "Luonto- ja ympäristöalan perustutkinto",
+            "sv": "Grundexamen i natur och miljö",
+            "en": "Vocational qualification in Natural and Environmental Protection"
+          },
+          "lyhytNimi": {
+            "fi": "Luonto- ja ympär.alan perust.",
+            "sv": "Grundexamen i natur och miljö",
+            "en": "Vocational qualification in Natural and Environmental Protection"
+          },
+          "koodistoUri": "koulutus",
+          "koodistoVersio": 12
+        },
+        "perusteenDiaarinumero": "OPH-2847-2017",
+        "perusteenNimi": {
+          "fi": "Luonto- ja ympäristöalan perustutkinto",
+          "sv": "Grundexamen i natur och miljö",
+          "en": "Vocational Qualification in Natural and Environmental Protection"
+        },
+        "koulutustyyppi": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Ammatillinen perustutkinto",
+            "sv": "Yrkesinriktad grundexamen",
+            "en": "Vocational upper secondary qualification"
+          },
+          "lyhytNimi": {
+            "fi": "Ammatillinen perustutkinto",
+            "sv": "Yrkesinriktad grundexamen"
+          },
+          "koodistoUri": "koulutustyyppi",
+          "koodistoVersio": 2
+        }
+      },
+      "suoritustapa": {
+        "koodiarvo": "reformi",
+        "nimi": {
+          "fi": "Reformin mukainen näyttö",
+          "sv": "Reform"
+        },
+        "lyhytNimi": {
+          "fi": "Reformi"
+        },
+        "koodistoUri": "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio": 1
+      },
+      "tutkintonimike": [
+        {
+          "koodiarvo": "10135",
+          "nimi": {
+            "fi": "Luonto-ohjaaja",
+            "sv": "Naturinstruktör"
+          },
+          "lyhytNimi": {
+            "fi": "Luonto-ohjaaja",
+            "sv": "Naturinstruktör"
+          },
+          "koodistoUri": "tutkintonimikkeet",
+          "koodistoVersio": 2
+        }
+      ],
+      "osaamisala": [
+        {
+          "osaamisala": {
+            "koodiarvo": "1764",
+            "nimi": {
+              "fi": "Luontoalan osaamisala",
+              "sv": "Kompetensområdet för natur"
+            },
+            "lyhytNimi": {
+              "fi": "Luontoalan osaamisala",
+              "sv": "Kompetensområdet för natur"
+            },
+            "koodistoUri": "osaamisala",
+            "koodistoVersio": 3
+          }
+        }
+      ],
+      "toimipiste": {
+        "oid": "1.2.246.562.10.3232323233232332323222",
+        "nimi": {
+          "fi": "Äyhtävän ammattiopisto, Äyhtävä, Norsukuja 3"
+        },
+        "kotipaikka": {
+          "koodiarvo": "997",
+          "nimi": {
+            "fi": "Äyhtävä",
+            "sv": "Äyhtävä"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "alkamispäivä": "2018-08-14",
+      "vahvistus": {
+        "päivä": "2019-08-30",
+        "paikkakunta": {
+          "koodiarvo": "997",
+          "nimi": {
+            "fi": "Äyhtävä",
+            "sv": "Äyhtävä"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        },
+        "myöntäjäOrganisaatio": {
+          "oid": "1.2.246.562.10.12212121222",
+          "oppilaitosnumero": {
+            "koodiarvo": "19821",
+            "nimi": {
+              "fi": "Äyhtävän ammattiopisto"
+            },
+            "koodistoUri": "oppilaitosnumero",
+            "koodistoVersio": 1
+          },
+          "nimi": {
+            "fi": "Äyhtävän ammattiopisto"
+          },
+          "kotipaikka": {
+            "koodiarvo": "997",
+            "nimi": {
+              "fi": "Äyhtävä",
+              "sv": "Äyhtävä"
+            },
+            "koodistoUri": "kunta",
+            "koodistoVersio": 2
+          }
+        },
+        "myöntäjäHenkilöt": [
+          {
+            "nimi": "Frank Johtaja",
+            "titteli": {
+              "fi": "Tirehtööri"
+            },
+            "organisaatio": {
+              "oid": "1.2.246.562.10.11122132323",
+              "oppilaitosnumero": {
+                "koodiarvo": "32322",
+                "nimi": {
+                  "fi": "Äyhtävän ammattiopisto"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Äyhtävän ammattiopisto"
+              },
+              "kotipaikka": {
+                "koodiarvo": "999",
+                "nimi": {
+                  "fi": "Äyhtävä",
+                  "sv": "Äyhtävä"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            }
+          }
+        ]
+      },
+      "suorituskieli": {
+        "koodiarvo": "FI",
+        "nimi": {
+          "fi": "suomi",
+          "sv": "finska",
+          "en": "Finnish"
+        },
+        "lyhytNimi": {
+          "fi": "suomi",
+          "sv": "finska",
+          "en": "Finnish"
+        },
+        "koodistoUri": "kieli",
+        "koodistoVersio": 1
+      },
+      "osaamisenHankkimistavat": [
+        {
+          "alku": "2018-12-10",
+          "loppu": "2018-12-31",
+          "osaamisenHankkimistapa": {
+            "tunniste": {
+              "koodiarvo": "koulutussopimus",
+              "nimi": {
+                "fi": "Koulutussopimus",
+                "sv": "Utbildningsavtal"
+              },
+              "koodistoUri": "osaamisenhankkimistapa",
+              "koodistoVersio": 1
+            }
+          }
+        },
+        {
+          "alku": "2019-06-03",
+          "loppu": "2019-07-12",
+          "osaamisenHankkimistapa": {
+            "tunniste": {
+              "koodiarvo": "koulutussopimus",
+              "nimi": {
+                "fi": "Koulutussopimus",
+                "sv": "Utbildningsavtal"
+              },
+              "koodistoUri": "osaamisenhankkimistapa",
+              "koodistoVersio": 1
+            }
+          }
+        }
+      ],
+      "koulutussopimukset": [
+        {
+          "alku": "2018-12-10",
+          "loppu": "2018-12-31",
+          "työssäoppimispaikka": {
+            "fi": "Yksityinen asiakaskohde"
+          },
+          "paikkakunta": {
+            "koodiarvo": "997",
+            "nimi": {
+              "fi": "Äyhtävä",
+              "sv": "Äyhtävä"
+            },
+            "koodistoUri": "kunta",
+            "koodistoVersio": 2
+          },
+          "maa": {
+            "koodiarvo": "246",
+            "nimi": {
+              "fi": "Suomi",
+              "sv": "Finland",
+              "en": "Finland"
+            },
+            "lyhytNimi": {
+              "fi": "FI",
+              "sv": "FI",
+              "en": "FI"
+            },
+            "koodistoUri": "maatjavaltiot2",
+            "koodistoVersio": 2
+          }
+        },
+        {
+          "alku": "2019-06-03",
+          "loppu": "2019-07-12",
+          "työssäoppimispaikka": {
+            "fi": "Yksityinen asiakaskohde"
+          },
+          "paikkakunta": {
+            "koodiarvo": "997",
+            "nimi": {
+              "fi": "Äyhtävä",
+              "sv": "Äyhtävä"
+            },
+            "koodistoUri": "kunta",
+            "koodistoVersio": 2
+          },
+          "maa": {
+            "koodiarvo": "246",
+            "nimi": {
+              "fi": "Suomi",
+              "sv": "Finland",
+              "en": "Finland"
+            },
+            "lyhytNimi": {
+              "fi": "FI",
+              "sv": "FI",
+              "en": "FI"
+            },
+            "koodistoUri": "maatjavaltiot2",
+            "koodistoVersio": 2
+          }
+        }
+      ],
+      "osasuoritukset": [],
+      "tyyppi": {
+        "koodiarvo": "ammatillinentutkinto",
+        "nimi": {
+          "fi": "Ammatillinen tutkinto",
+          "sv": "Yrkesinriktad examen",
+          "en": "Vocational education  qualification"
+        },
+        "koodistoUri": "suorituksentyyppi",
+        "koodistoVersio": 1
+      }
+    }
+  ],
+  "lisätiedot": {
+    "oikeusMaksuttomaanAsuntolapaikkaan": true,
+    "henkilöstökoulutus": false,
+    "koulutusvienti": false
+  },
+  "tyyppi": {
+    "koodiarvo": "ammatillinenkoulutus",
+    "nimi": {
+      "fi": "Ammatillinen koulutus",
+      "sv": "Yrkesutbildning"
+    },
+    "lyhytNimi": {
+      "fi": "Ammatillinen koulutus"
+    },
+    "koodistoUri": "opiskeluoikeudentyyppi",
+    "koodistoVersio": 1
+  },
+  "alkamispäivä": "2018-08-14",
+  "päättymispäivä": "2019-08-30"
+}

--- a/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-05.json
+++ b/src/test/resources/fi/vm/sade/valinta/kooste/valintalaskenta/opiskeluoikeus-1.2.246.562.15.12442534343-versio-2019-10-05.json
@@ -1,0 +1,435 @@
+{
+  "oid": "1.2.246.562.15.12442534343",
+  "versionumero": 2,
+  "aikaleima": "2019-10-05T23:10:27.540254",
+  "lähdejärjestelmänId": {
+    "id": "153903",
+    "lähdejärjestelmä": {
+      "koodiarvo": "primus",
+      "nimi": {
+        "fi": "primus"
+      },
+      "koodistoUri": "lahdejarjestelma",
+      "koodistoVersio": 1
+    }
+  },
+  "oppilaitos": {
+    "oid": "1.2.246.562.10.43432423433",
+    "oppilaitosnumero": {
+      "koodiarvo": "83712",
+      "nimi": {
+        "fi": "Äyhtävän ammattiopisto"
+      },
+      "koodistoUri": "oppilaitosnumero",
+      "koodistoVersio": 1
+    },
+    "nimi": {
+      "fi": "Äyhtävän ammattiopisto"
+    },
+    "kotipaikka": {
+      "koodiarvo": "997",
+      "nimi": {
+        "fi": "Äyhtävä",
+        "sv": "Äyhtävä"
+      },
+      "koodistoUri": "kunta",
+      "koodistoVersio": 2
+    }
+  },
+  "koulutustoimija": {
+    "oid": "1.2.246.562.10.43434243433",
+    "nimi": {
+      "fi": "Äyhtävän Koulutuskuntayhtymä"
+    },
+    "yTunnus": "0025266-2",
+    "kotipaikka": {
+      "koodiarvo": "997",
+      "nimi": {
+        "fi": "Äyhtävä",
+        "sv": "Äyhtävä"
+      },
+      "koodistoUri": "kunta",
+      "koodistoVersio": 2
+    }
+  },
+  "arvioituPäättymispäivä": "2019-08-12",
+  "ostettu": false,
+  "tila": {
+    "opiskeluoikeusjaksot": [
+      {
+        "alku": "2018-08-14",
+        "tila": {
+          "koodiarvo": "lasna",
+          "nimi": {
+            "fi": "Läsnä",
+            "sv": "Närvarande",
+            "en": "Present"
+          },
+          "koodistoUri": "koskiopiskeluoikeudentila",
+          "koodistoVersio": 1
+        },
+        "opintojenRahoitus": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Valtionosuusrahoitteinen koulutus",
+            "sv": "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri": "opintojenrahoitus",
+          "koodistoVersio": 1
+        }
+      },
+      {
+        "alku": "2019-01-01",
+        "tila": {
+          "koodiarvo": "lasna",
+          "nimi": {
+            "fi": "Läsnä",
+            "sv": "Närvarande",
+            "en": "Present"
+          },
+          "koodistoUri": "koskiopiskeluoikeudentila",
+          "koodistoVersio": 1
+        },
+        "opintojenRahoitus": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Valtionosuusrahoitteinen koulutus",
+            "sv": "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri": "opintojenrahoitus",
+          "koodistoVersio": 1
+        }
+      },
+      {
+        "alku": "2019-08-30",
+        "tila": {
+          "koodiarvo": "valmistunut",
+          "nimi": {
+            "fi": "Valmistunut",
+            "sv": "Utexaminerad",
+            "en": "Graduated"
+          },
+          "koodistoUri": "koskiopiskeluoikeudentila",
+          "koodistoVersio": 1
+        },
+        "opintojenRahoitus": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Valtionosuusrahoitteinen koulutus",
+            "sv": "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri": "opintojenrahoitus",
+          "koodistoVersio": 1
+        }
+      }
+    ]
+  },
+  "suoritukset": [
+    {
+      "koulutusmoduuli": {
+        "tunniste": {
+          "koodiarvo": "361902",
+          "nimi": {
+            "fi": "Luonto- ja ympäristöalan perustutkinto",
+            "sv": "Grundexamen i natur och miljö",
+            "en": "Vocational qualification in Natural and Environmental Protection"
+          },
+          "lyhytNimi": {
+            "fi": "Luonto- ja ympär.alan perust.",
+            "sv": "Grundexamen i natur och miljö",
+            "en": "Vocational qualification in Natural and Environmental Protection"
+          },
+          "koodistoUri": "koulutus",
+          "koodistoVersio": 12
+        },
+        "perusteenDiaarinumero": "OPH-2847-2017",
+        "perusteenNimi": {
+          "fi": "Luonto- ja ympäristöalan perustutkinto",
+          "sv": "Grundexamen i natur och miljö",
+          "en": "Vocational Qualification in Natural and Environmental Protection"
+        },
+        "koulutustyyppi": {
+          "koodiarvo": "1",
+          "nimi": {
+            "fi": "Ammatillinen perustutkinto",
+            "sv": "Yrkesinriktad grundexamen",
+            "en": "Vocational upper secondary qualification"
+          },
+          "lyhytNimi": {
+            "fi": "Ammatillinen perustutkinto",
+            "sv": "Yrkesinriktad grundexamen"
+          },
+          "koodistoUri": "koulutustyyppi",
+          "koodistoVersio": 2
+        }
+      },
+      "suoritustapa": {
+        "koodiarvo": "reformi",
+        "nimi": {
+          "fi": "Reformin mukainen näyttö",
+          "sv": "Reform"
+        },
+        "lyhytNimi": {
+          "fi": "Reformi"
+        },
+        "koodistoUri": "ammatillisentutkinnonsuoritustapa",
+        "koodistoVersio": 1
+      },
+      "tutkintonimike": [
+        {
+          "koodiarvo": "10135",
+          "nimi": {
+            "fi": "Luonto-ohjaaja",
+            "sv": "Naturinstruktör"
+          },
+          "lyhytNimi": {
+            "fi": "Luonto-ohjaaja",
+            "sv": "Naturinstruktör"
+          },
+          "koodistoUri": "tutkintonimikkeet",
+          "koodistoVersio": 2
+        }
+      ],
+      "osaamisala": [
+        {
+          "osaamisala": {
+            "koodiarvo": "1764",
+            "nimi": {
+              "fi": "Luontoalan osaamisala",
+              "sv": "Kompetensområdet för natur"
+            },
+            "lyhytNimi": {
+              "fi": "Luontoalan osaamisala",
+              "sv": "Kompetensområdet för natur"
+            },
+            "koodistoUri": "osaamisala",
+            "koodistoVersio": 3
+          }
+        }
+      ],
+      "toimipiste": {
+        "oid": "1.2.246.562.10.3232323233232332323222",
+        "nimi": {
+          "fi": "Äyhtävän ammattiopisto, Äyhtävä, Norsukuja 3"
+        },
+        "kotipaikka": {
+          "koodiarvo": "997",
+          "nimi": {
+            "fi": "Äyhtävä",
+            "sv": "Äyhtävä"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "alkamispäivä": "2018-08-14",
+      "vahvistus": {
+        "päivä": "2019-08-30",
+        "paikkakunta": {
+          "koodiarvo": "997",
+          "nimi": {
+            "fi": "Äyhtävä",
+            "sv": "Äyhtävä"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        },
+        "myöntäjäOrganisaatio": {
+          "oid": "1.2.246.562.10.12212121222",
+          "oppilaitosnumero": {
+            "koodiarvo": "19821",
+            "nimi": {
+              "fi": "Äyhtävän ammattiopisto"
+            },
+            "koodistoUri": "oppilaitosnumero",
+            "koodistoVersio": 1
+          },
+          "nimi": {
+            "fi": "Äyhtävän ammattiopisto"
+          },
+          "kotipaikka": {
+            "koodiarvo": "997",
+            "nimi": {
+              "fi": "Äyhtävä",
+              "sv": "Äyhtävä"
+            },
+            "koodistoUri": "kunta",
+            "koodistoVersio": 2
+          }
+        },
+        "myöntäjäHenkilöt": [
+          {
+            "nimi": "Frank Johtaja",
+            "titteli": {
+              "fi": "Tirehtööri"
+            },
+            "organisaatio": {
+              "oid": "1.2.246.562.10.11122132323",
+              "oppilaitosnumero": {
+                "koodiarvo": "32322",
+                "nimi": {
+                  "fi": "Äyhtävän ammattiopisto"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Äyhtävän ammattiopisto"
+              },
+              "kotipaikka": {
+                "koodiarvo": "999",
+                "nimi": {
+                  "fi": "Äyhtävä",
+                  "sv": "Äyhtävä"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            }
+          }
+        ]
+      },
+      "suorituskieli": {
+        "koodiarvo": "FI",
+        "nimi": {
+          "fi": "suomi",
+          "sv": "finska",
+          "en": "Finnish"
+        },
+        "lyhytNimi": {
+          "fi": "suomi",
+          "sv": "finska",
+          "en": "Finnish"
+        },
+        "koodistoUri": "kieli",
+        "koodistoVersio": 1
+      },
+      "osaamisenHankkimistavat": [
+        {
+          "alku": "2018-12-10",
+          "loppu": "2018-12-31",
+          "osaamisenHankkimistapa": {
+            "tunniste": {
+              "koodiarvo": "koulutussopimus",
+              "nimi": {
+                "fi": "Koulutussopimus",
+                "sv": "Utbildningsavtal"
+              },
+              "koodistoUri": "osaamisenhankkimistapa",
+              "koodistoVersio": 1
+            }
+          }
+        },
+        {
+          "alku": "2019-06-03",
+          "loppu": "2019-07-12",
+          "osaamisenHankkimistapa": {
+            "tunniste": {
+              "koodiarvo": "koulutussopimus",
+              "nimi": {
+                "fi": "Koulutussopimus",
+                "sv": "Utbildningsavtal"
+              },
+              "koodistoUri": "osaamisenhankkimistapa",
+              "koodistoVersio": 1
+            }
+          }
+        }
+      ],
+      "koulutussopimukset": [
+        {
+          "alku": "2018-12-10",
+          "loppu": "2018-12-31",
+          "työssäoppimispaikka": {
+            "fi": "Yksityinen asiakaskohde"
+          },
+          "paikkakunta": {
+            "koodiarvo": "997",
+            "nimi": {
+              "fi": "Äyhtävä",
+              "sv": "Äyhtävä"
+            },
+            "koodistoUri": "kunta",
+            "koodistoVersio": 2
+          },
+          "maa": {
+            "koodiarvo": "246",
+            "nimi": {
+              "fi": "Suomi",
+              "sv": "Finland",
+              "en": "Finland"
+            },
+            "lyhytNimi": {
+              "fi": "FI",
+              "sv": "FI",
+              "en": "FI"
+            },
+            "koodistoUri": "maatjavaltiot2",
+            "koodistoVersio": 2
+          }
+        },
+        {
+          "alku": "2019-06-03",
+          "loppu": "2019-07-12",
+          "työssäoppimispaikka": {
+            "fi": "Yksityinen asiakaskohde"
+          },
+          "paikkakunta": {
+            "koodiarvo": "997",
+            "nimi": {
+              "fi": "Äyhtävä",
+              "sv": "Äyhtävä"
+            },
+            "koodistoUri": "kunta",
+            "koodistoVersio": 2
+          },
+          "maa": {
+            "koodiarvo": "246",
+            "nimi": {
+              "fi": "Suomi",
+              "sv": "Finland",
+              "en": "Finland"
+            },
+            "lyhytNimi": {
+              "fi": "FI",
+              "sv": "FI",
+              "en": "FI"
+            },
+            "koodistoUri": "maatjavaltiot2",
+            "koodistoVersio": 2
+          }
+        }
+      ],
+      "osasuoritukset": [],
+      "tyyppi": {
+        "koodiarvo": "ammatillinentutkinto",
+        "nimi": {
+          "fi": "Ammatillinen tutkinto",
+          "sv": "Yrkesinriktad examen",
+          "en": "Vocational education  qualification"
+        },
+        "koodistoUri": "suorituksentyyppi",
+        "koodistoVersio": 1
+      }
+    }
+  ],
+  "lisätiedot": {
+    "oikeusMaksuttomaanAsuntolapaikkaan": true,
+    "henkilöstökoulutus": false,
+    "koulutusvienti": false
+  },
+  "tyyppi": {
+    "koodiarvo": "ammatillinenkoulutus",
+    "nimi": {
+      "fi": "Ammatillinen koulutus",
+      "sv": "Yrkesutbildning"
+    },
+    "lyhytNimi": {
+      "fi": "Ammatillinen koulutus"
+    },
+    "koodistoUri": "opiskeluoikeudentyyppi",
+    "koodistoVersio": 1
+  },
+  "alkamispäivä": "2018-08-14",
+  "päättymispäivä": "2019-08-30"
+}


### PR DESCRIPTION
Valintaperusteissa voi syöttää (VTKU-110-versiossa https://github.com/Opetushallitus/valintaperusteet/pull/22 ) "iteroi ammatilliset perustutkinnot" -funktiolle kaksi päivämääräparametria: valmistumisen takarajan, sekä "leikkuripäivämäärän", jota uudempia päivityksiä Koskeen ei huomioida.

Täällä Valintalaskentakoostepalvelussa leikkuripäivämäärä haetaan valintaperusteista, ja jos ammatillisen perustutkinnon opiskeluoikeuden aikaleima on myöhemmin kuin leikkuripäivämääränä, yritetään hakea tuorein sellainen versio, jota ei ole päivitetty leikkuripäivämäärän jälkeen.

Tämä tehdään kutsumalla versio kerrallaan Kosken APIa, joka palauttaa opiskeluoikeuden tietyn version, kunnes löydetään joko
* versio, jonka aikaleima on viimeistään leikkuripäivämääränä tai
* versio 1, joka on Koskessa ensimmäinen versio, joten sitä vanhempia on turha lähteä hakemaan.