### PR TITLE
VTKU-151 : valintalaskennan tulosexcel sekaisin

### DIFF
--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
@@ -17,8 +17,7 @@ import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.ValintatietoValinnanva
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.ValintatietoValintatapajonoDTO;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.CompareToBuilder;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -145,6 +144,9 @@ public class ValintalaskennanTulosExcel {
         public final boolean omaOpintopolku;
 
         public DynamicColumnHeader(FunktioTulosDTO funktioTulosDTO) {
+            if (org.apache.commons.lang3.StringUtils.isBlank(funktioTulosDTO.getTunniste())) {
+                throw new IllegalArgumentException("Tyhjä funktiotuloksen tunniste ei ole sallittu:" + ToStringBuilder.reflectionToString(funktioTulosDTO));
+            }
             this.tunniste = funktioTulosDTO.getTunniste();
             this.nimiFi = funktioTulosDTO.getNimiFi();
             this.nimiSv = funktioTulosDTO.getNimiSv();
@@ -154,19 +156,19 @@ public class ValintalaskennanTulosExcel {
 
         @Override
         public int hashCode() {
-            return HashCodeBuilder.reflectionHashCode(this);
+            return tunniste.hashCode();
         }
 
         @Override
         public boolean equals(Object obj) {
-            return EqualsBuilder.reflectionEquals(this, obj);
+            if (!(obj instanceof DynamicColumnHeader)) {
+                return false;
+            }
+            return ((DynamicColumnHeader) obj).tunniste.equals(tunniste);
         }
 
         @Override
         public int compareTo(DynamicColumnHeader o) {
-            if (tunniste == null) {
-                return -1;
-            }
             return tunniste.compareTo(o.tunniste);
         }
     }

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
@@ -68,7 +68,7 @@ public class ValintalaskennanTulosExcel {
                                         dynamicColumnHeaders.stream().map(h -> h.tunniste))
                                     .collect(Collectors.toList());
                                 addRow(sheet, allColumnHeaders);
-                                addJonosijaRows(hakemusByOid, jono, sheet);
+                                addJonosijaRows(hakemusByOid, jono, sheet, dynamicColumnHeaders);
                             }
                         }
                 );
@@ -91,11 +91,17 @@ public class ValintalaskennanTulosExcel {
         return new ValintatapaJonoSheet(indexedJonoSheet.getValue(), truncatedSheetName);
     }
 
-    private static void addJonosijaRows(Map<String, HakemusWrapper> hakemusByOid, ValintatietoValintatapajonoDTO jono, XSSFSheet sheet) {
+    private static void addJonosijaRows(Map<String,HakemusWrapper> hakemusByOid,
+                                        ValintatietoValintatapajonoDTO jono,
+                                        XSSFSheet sheet,
+                                        List<DynamicColumnHeader> dynamicColumnHeaders) {
         sortedJonosijat(jono)
                 .map(hakija -> {
                     final Stream<Column> fixedColumnValuesStream = fixedColumns.stream();
-                    final Stream<Column> dynamicColumnValuesStream = hakija.getFunktioTulokset().stream().map(FunktioTulosDTO::getTunniste).map(t -> new Column(t, 14, rivi -> extractValue(t, rivi)));
+                    final Stream<Column> dynamicColumnValuesStream = dynamicColumnHeaders.stream()
+                        .map(header ->
+                            new Column(header.tunniste, 14, rivi ->
+                                extractValue(header.tunniste, rivi)));
                     final HakemusRivi hakemusRivi = new HakemusRivi(hakija, hakemusByOid.get(hakija.getHakemusOid()));
                     return Stream.concat(fixedColumnValuesStream, dynamicColumnValuesStream)
                             .map(column -> column.extractor.apply(hakemusRivi))

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
@@ -15,8 +15,8 @@ import fi.vm.sade.valintalaskenta.domain.dto.JonosijaDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.ValinnanvaiheDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.ValintatietoValinnanvaiheDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.valintatieto.ValintatietoValintatapajonoDTO;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
@@ -144,7 +144,7 @@ public class ValintalaskennanTulosExcel {
         public final boolean omaOpintopolku;
 
         public DynamicColumnHeader(FunktioTulosDTO funktioTulosDTO) {
-            if (org.apache.commons.lang3.StringUtils.isBlank(funktioTulosDTO.getTunniste())) {
+            if (StringUtils.isBlank(funktioTulosDTO.getTunniste())) {
                 throw new IllegalArgumentException("Tyhjä funktiotuloksen tunniste ei ole sallittu:" + ToStringBuilder.reflectionToString(funktioTulosDTO));
             }
             this.tunniste = funktioTulosDTO.getTunniste();

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
@@ -1,13 +1,14 @@
 package fi.vm.sade.valinta.kooste.valintalaskentatulos.excel;
 
+import static fi.vm.sade.valinta.kooste.viestintapalvelu.dto.Teksti.getTeksti;
+import static java.util.Arrays.asList;
 import com.codepoetics.protonpack.Indexed;
 import com.codepoetics.protonpack.StreamUtils;
+
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakuV1RDTO;
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakukohdeV1RDTO;
-import fi.vm.sade.valinta.kooste.external.resource.hakuapp.dto.Hakemus;
 import fi.vm.sade.valinta.kooste.util.ExcelExportUtil;
 import fi.vm.sade.valinta.kooste.util.HakemusWrapper;
-import fi.vm.sade.valinta.kooste.util.HakuappHakemusWrapper;
 import fi.vm.sade.valintalaskenta.domain.dto.FunktioTulosDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.JarjestyskriteeritulosDTO;
 import fi.vm.sade.valintalaskenta.domain.dto.JonosijaDTO;
@@ -20,14 +21,16 @@ import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static fi.vm.sade.valinta.kooste.viestintapalvelu.dto.Teksti.getTeksti;
-import static java.util.Arrays.asList;
-import static org.apache.commons.lang.StringUtils.trimToEmpty;
 
 
 public class ValintalaskennanTulosExcel {
@@ -137,7 +140,7 @@ public class ValintalaskennanTulosExcel {
         }
     }
 
-    private static List<Column> fixedColumns = Arrays.asList(
+    private static final List<Column> fixedColumns = Arrays.asList(
             new Column("Jonosija", 14, rivi -> String.valueOf(rivi.hakija.getJonosija())),
             new Column("Sukunimi", 20, rivi -> rivi.hakemus.getSukunimi()),
             new Column("Etunimi", 20, rivi -> rivi.hakemus.getEtunimet()),
@@ -160,7 +163,7 @@ public class ValintalaskennanTulosExcel {
     }
     private static JarjestyskriteeritulosDTO getJarjestyskriteeri(final JonosijaDTO hakija) {
         return hakija.getJarjestyskriteerit().isEmpty()
-            ? new JarjestyskriteeritulosDTO(null, hakija.getTuloksenTila(), Collections.EMPTY_MAP, 1, "")
+            ? new JarjestyskriteeritulosDTO(null, hakija.getTuloksenTila(), Collections.emptyMap(), 1, "")
             : hakija.getJarjestyskriteerit().first();
     }
 

--- a/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/excel/ValintalaskennanTulosExcel.java
@@ -121,6 +121,7 @@ public class ValintalaskennanTulosExcel {
             .flatMap(js -> js.getFunktioTulokset().stream())
             .map(DynamicColumnHeader::new)
             .distinct()
+            .sorted()
             .collect(Collectors.toList());
     }
 
@@ -144,7 +145,7 @@ public class ValintalaskennanTulosExcel {
         }
     }
 
-    private static class DynamicColumnHeader {
+    private static class DynamicColumnHeader implements Comparable<DynamicColumnHeader> {
         public final String tunniste;
         public final String nimiFi;
         public final String nimiSv;
@@ -167,6 +168,14 @@ public class ValintalaskennanTulosExcel {
         @Override
         public boolean equals(Object obj) {
             return EqualsBuilder.reflectionEquals(this, obj);
+        }
+
+        @Override
+        public int compareTo(DynamicColumnHeader o) {
+            if (tunniste == null) {
+                return -1;
+            }
+            return tunniste.compareTo(o.tunniste);
         }
     }
 

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskennanTulosExcelTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskennanTulosExcelTest.java
@@ -1,5 +1,12 @@
 package fi.vm.sade.valinta.kooste.valintalaskentatulos;
 
+import static fi.vm.sade.valintalaskenta.domain.valinta.JarjestyskriteerituloksenTila.HYVAKSYTTAVISSA;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakuV1RDTO;
 import fi.vm.sade.tarjonta.service.resources.v1.dto.HakukohdeV1RDTO;
 import fi.vm.sade.valinta.kooste.excel.Excel;
@@ -29,30 +36,30 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.*;
-
-import static fi.vm.sade.valintalaskenta.domain.valinta.JarjestyskriteerituloksenTila.HYVAKSYTTAVISSA;
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
 
 public class ValintalaskennanTulosExcelTest {
-    private HakukohdeV1RDTO hakukohdeDTO = new HakukohdeV1RDTO();
+    private final HakukohdeV1RDTO hakukohdeDTO = new HakukohdeV1RDTO();
 
     {
         hakukohdeDTO.setHakukohteenNimet(map("fi", "Hakukohde 1"));
         hakukohdeDTO.setTarjoajaNimet(map("fi", "Tarjoaja 1"));
     }
 
-    private HakuV1RDTO haku = new HakuV1RDTO();
+    private final HakuV1RDTO haku = new HakuV1RDTO();
 
     {
         haku.setNimi(map("fi", "Haku 1"));
     }
 
-    private DateTime nyt = DateTime.now();
+    private final DateTime nyt = DateTime.now();
 
     @Test
     public void sheetNames() {
@@ -182,7 +189,7 @@ public class ValintalaskennanTulosExcelTest {
 
 
     private <T> HashMap<String, T> map(final String key, final T value) {
-        return new HashMap<String, T>() {{
+        return new HashMap<>() {{
             put(key, value);
         }};
     }

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskennanTulosExcelTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskennanTulosExcelTest.java
@@ -96,8 +96,8 @@ public class ValintalaskennanTulosExcelTest {
                         asList("Päivämäärä", ExcelExportUtil.DATE_FORMAT.format(nyt.toDate())), // "01.01.1970 02.00"
                         asList("Jono", "Jono 1"),
                         Collections.emptyList(),
-                        asList("Jonosija", "Sukunimi", "Etunimi", "Henkilötunnus", "Sähköpostiosoite", "Hakemus OID", "Hakutoive", "Laskennan tulos", "Selite", "Kokonaispisteet", "pääsykoetulos", "keskiarvo"),
-                        asList("2", "Suku 1", "Etu 1", "010101-123N", "sukuetu1@testi.fi", "Hakemus 1", "1", "HYVAKSYTTAVISSA", "", "666", "10", "9")
+                        asList("Jonosija", "Sukunimi", "Etunimi", "Henkilötunnus", "Sähköpostiosoite", "Hakemus OID", "Hakutoive", "Laskennan tulos", "Selite", "Kokonaispisteet", "keskiarvo", "pääsykoetulos"),
+                        asList("2", "Suku 1", "Etu 1", "010101-123N", "sukuetu1@testi.fi", "Hakemus 1", "1", "HYVAKSYTTAVISSA", "", "666", "9", "10")
                 ), getWorksheetData(workbook.getSheetAt(0)));
     }
 
@@ -120,8 +120,8 @@ public class ValintalaskennanTulosExcelTest {
                         asList("Päivämäärä", ExcelExportUtil.DATE_FORMAT.format(nyt.toDate())), // "01.01.1970 02.00"
                         asList("Jono", "Jono 1"),
                         Collections.emptyList(),
-                        asList("Jonosija", "Sukunimi", "Etunimi", "Henkilötunnus", "Sähköpostiosoite", "Hakemus OID", "Hakutoive", "Laskennan tulos", "Selite", "Kokonaispisteet", "pääsykoetulos", "keskiarvo"),
-                        asList("2", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000063", "1", "HYVAKSYTTAVISSA", "", "666", "10", "9")
+                        asList("Jonosija", "Sukunimi", "Etunimi", "Henkilötunnus", "Sähköpostiosoite", "Hakemus OID", "Hakutoive", "Laskennan tulos", "Selite", "Kokonaispisteet", "keskiarvo", "pääsykoetulos"),
+                        asList("2", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000063", "1", "HYVAKSYTTAVISSA", "", "666", "9", "10")
                 ), getWorksheetData(ataruWorkbook.getSheetAt(0)));
     }
 
@@ -147,9 +147,9 @@ public class ValintalaskennanTulosExcelTest {
                 asList("Päivämäärä", ExcelExportUtil.DATE_FORMAT.format(nyt.toDate())), // "01.01.1970 02.00"
                 asList("Jono", "Jono 1"),
                 Collections.emptyList(),
-                asList("Jonosija", "Sukunimi", "Etunimi", "Henkilötunnus", "Sähköpostiosoite", "Hakemus OID", "Hakutoive", "Laskennan tulos", "Selite", "Kokonaispisteet", "pääsykoetulos", "lukion keskiarvo", "Ammatillisen perustutkinnon keskiarvo"),
-                asList("1", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000064", "1", "HYVAKSYTTAVISSA", "", "19", "8", "9", ""),
-                asList("2", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000065", "1", "HYVAKSYTTAVISSA", "", "17", "10", "", "3.2")
+                asList("Jonosija", "Sukunimi", "Etunimi", "Henkilötunnus", "Sähköpostiosoite", "Hakemus OID", "Hakutoive", "Laskennan tulos", "Selite", "Kokonaispisteet", "Ammatillisen perustutkinnon keskiarvo", "lukion keskiarvo", "pääsykoetulos"),
+                asList("1", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000064", "1", "HYVAKSYTTAVISSA", "", "19", "", "9", "8"),
+                asList("2", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000065", "1", "HYVAKSYTTAVISSA", "", "17", "3.2", "", "10")
             ), getWorksheetData(ataruWorkbook.getSheetAt(0)));
     }
 

--- a/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskennanTulosExcelTest.java
+++ b/src/test/java/fi/vm/sade/valinta/kooste/valintalaskentatulos/ValintalaskennanTulosExcelTest.java
@@ -126,6 +126,34 @@ public class ValintalaskennanTulosExcelTest {
     }
 
     @Test
+    public void sarakkeidenSisaltoOnOikeinVaikkaSeTulisiEriJarjestyksessaEriHakijoille() {
+        XSSFWorkbook ataruWorkbook = ValintalaskennanTulosExcel.luoExcel(
+            haku,
+            hakukohdeDTO,
+            Collections.singletonList(
+                valinnanvaihe(1, nyt.toDate(), Collections.singletonList(
+                    valintatapajono(1, ataruJonosijatJoissaOnEriSarakkeita())
+                ))),
+            asList(
+                MockAtaruAsyncResource.getAtaruHakemusWrapper("1.2.246.562.11.00000000000000000064"),
+                MockAtaruAsyncResource.getAtaruHakemusWrapper("1.2.246.562.11.00000000000000000065")));
+
+        assertEquals(
+            asList(
+                asList("Haku", "Haku 1"),
+                asList("Tarjoaja", "Tarjoaja 1"),
+                asList("Hakukohde", "Hakukohde 1"),
+                asList("Vaihe", "Vaihe 1"),
+                asList("Päivämäärä", ExcelExportUtil.DATE_FORMAT.format(nyt.toDate())), // "01.01.1970 02.00"
+                asList("Jono", "Jono 1"),
+                Collections.emptyList(),
+                asList("Jonosija", "Sukunimi", "Etunimi", "Henkilötunnus", "Sähköpostiosoite", "Hakemus OID", "Hakutoive", "Laskennan tulos", "Selite", "Kokonaispisteet", "pääsykoetulos", "lukion keskiarvo", "Ammatillisen perustutkinnon keskiarvo"),
+                asList("1", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000064", "1", "HYVAKSYTTAVISSA", "", "19", "8", "9", ""),
+                asList("2", "TAUsuL4BQc", "Zl2A5", "020202A0202", "ukhBW@example.com", "1.2.246.562.11.00000000000000000065", "1", "HYVAKSYTTAVISSA", "", "17", "10", "", "3.2")
+            ), getWorksheetData(ataruWorkbook.getSheetAt(0)));
+    }
+
+    @Test
     public void emptySheet() {
         XSSFWorkbook workbook = ValintalaskennanTulosExcel.luoExcel(haku, hakukohdeDTO, asList(
                 valinnanvaihe(1, nyt.toDate(), asList(
@@ -261,6 +289,17 @@ public class ValintalaskennanTulosExcelTest {
                 new JonosijaDTO(2, "1.2.246.562.11.00000000000000000063", "1.2.246.562.24.86368188549",
                         jarjestyskriteerit(HYVAKSYTTAVISSA, Collections.emptyMap(), new BigDecimal(666)),
                         1, "Suku 1", "Etu 1", false, HYVAKSYTTAVISSA, Collections.emptyList(), Collections.emptyList(), Arrays.asList(new FunktioTulosDTO("pääsykoetulos", "10"), new FunktioTulosDTO("keskiarvo", "9")), false, false)
+        );
+    }
+
+    private List<JonosijaDTO> ataruJonosijatJoissaOnEriSarakkeita() {
+        return asList(
+            new JonosijaDTO(1, "1.2.246.562.11.00000000000000000064", "1.2.246.562.24.86368188550",
+                jarjestyskriteerit(HYVAKSYTTAVISSA, Collections.emptyMap(), new BigDecimal(19)),
+                1, "Lukiolainen", "Bob", false, HYVAKSYTTAVISSA, Collections.emptyList(), Collections.emptyList(), Arrays.asList(new FunktioTulosDTO("pääsykoetulos", "8"), new FunktioTulosDTO("lukion keskiarvo", "9")), false, false),
+            new JonosijaDTO(2, "1.2.246.562.11.00000000000000000065", "1.2.246.562.24.86368188551",
+                jarjestyskriteerit(HYVAKSYTTAVISSA, Collections.emptyMap(), new BigDecimal(17)),
+                1, "Ammattitutkittu", "Frank", false, HYVAKSYTTAVISSA, Collections.emptyList(), Collections.emptyList(), Arrays.asList(new FunktioTulosDTO("pääsykoetulos", "10"), new FunktioTulosDTO("Ammatillisen perustutkinnon keskiarvo", "3.2")), false, false)
         );
     }
 


### PR DESCRIPTION
Jos eri hakijoilla tule eri lista funktiotuloksia tai ne tulivat eri järjestyksessä, niin sekaisin mentiin.

Korjauksessa haetaan uniikit sarakeotsikot kaikkien jonon hakijoiden tuloksista, ja käytään niitä avaimina kun haetaan riveille arvot.