### PR TITLE
Bug 2174 pistetietojen tuonti

### DIFF
--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
@@ -247,10 +247,10 @@ public class PistesyottoExternalTuontiService {
         final HakemusDTO pistetiedotHakemukselle = hakemusJaHakutoiveet.hakemusDTO;
         List<OsallistuminenHakutoiveeseen> hakemuksenKokeetStream = pistetiedotHakemukselle.getValintakokeet().stream().flatMap(koe ->
             hakutoives.stream().flatMap(hakutoive -> {
-                // Valintakokeen tunnistetta ei löydy valintaperusteet
+                // Valintakokeen tunnistetta ei löydy tämän hakutoiveen valintaperusteista
                 if (!hakutoive.valintaperusteetDTO.stream().map(valintaperusteDTO -> valintaperusteDTO.getTunniste()).collect(Collectors.toSet()).contains(koe.getTunniste())) {
-                    String errorMessage = "Valintakoetta ei löydy annetulle tunnisteelle (" + koe.getTunniste() + ") käsiteltäessä hakemusta " + pistetiedotHakemukselle.getHakemusOid();
-                    LOG.error(errorMessage);
+                    String errorMessage = "Valintakoetta ei löydy annetulle tunnisteelle (" + koe.getTunniste() + ") käsiteltäessä hakemusta " + pistetiedotHakemukselle.getHakemusOid() + " hakutoiveelle " + hakutoive.hakukohdeOid;
+                    LOG.warn(errorMessage);
                     VirheDTO invalidIdentifier = new VirheDTO();
                     invalidIdentifier.setHakemusOid(pistetiedotHakemukselle.getHakemusOid());
                     invalidIdentifier.setVirhe(errorMessage);

--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
@@ -334,7 +334,7 @@ public class PistesyottoExternalTuontiService {
                                     List<Hakutoive> hakutoiveetList = h.hakutoiveet.stream().map(hakukohdeOid -> new Hakutoive(
                                             hakukohdeOid,
                                             hakukohdeOidToValintaperusteDTOMap.get(hakukohdeOid).getValintaperusteDTO(),
-                                            Optional.ofNullable(hakemusOidToValintakoeOsallistuminenDTOMap.get(hakukohdeOid)).orElse(Collections.emptyList()))).collect(Collectors.toList());
+                                            Optional.ofNullable(hakemusOidToValintakoeOsallistuminenDTOMap.get(pistetiedotHakemukselle.getHakemusOid())).orElse(Collections.emptyList()))).collect(Collectors.toList());
                                     return validoi(h, hakutoiveetList).map(osallistuminen -> {
                                         boolean isAuthorized = authorityCheck.test(osallistuminen.hakukohdeOid);
                                         if (isAuthorized) {

--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/service/PistesyottoExternalTuontiService.java
@@ -307,6 +307,7 @@ public class PistesyottoExternalTuontiService {
                         Map<String, HakukohdeJaValintaperusteDTO> hakukohdeOidToValintaperusteDTOMap = hakukohdeJaValintaperusteDTOs.stream().collect(
                                 Collectors.toMap(HakukohdeJaValintaperusteDTO::getHakukohdeOid, hh -> hh));
 
+                        osallistuminenDTOs.stream().forEach(o -> o.getHakutoiveet().forEach(ht -> ht.getValinnanVaiheet().forEach(vv -> vv.getValintakokeet())));
                         Map<String, List<ValintakoeOsallistuminenDTO>> hakemusOidToValintakoeOsallistuminenDTOMap = osallistuminenDTOs.stream().collect(
                                 Collectors.toMap(ValintakoeOsallistuminenDTO::getHakemusOid, Arrays::asList, (h0, h1) -> Lists.newArrayList(Iterables.concat(h0, h1))));
 
@@ -340,7 +341,6 @@ public class PistesyottoExternalTuontiService {
                                             return osallistuminen;
                                         } else {
                                             String errorMessage = "Tarvittavat muokkausoikeudet puuttuvat hakutoiveelle " + osallistuminen.hakukohdeOid;
-                                            LOG.error(errorMessage); //Fixme ehkä, näitä voi tulla aika paljon ja voivat olla turhahkoja.
                                             VirheDTO virheDTO = new VirheDTO();
                                             if (osallistuminen.isVirhe()) {
                                                 virheDTO.setHakemusOid(osallistuminen.asVirheDTO().getHakemusOid());


### PR DESCRIPTION
Pääasiassa uudelleennimeämisiä ymmärrettävyyden parantamiseksi.

Olennainen toiminnallinen korjaus on popsia arvo hakemusten ValintakoeOsallistuminenDTO:t sisältävästä mapista hakemusOidilla entisen hakukohdeOidin, jolla mitään ei tietenkään voinut koskaan löytyä, sijaan.

Huudellaan joistakin virheistä myös logille sen lisäksi, että palautetaan niitä rajapintavastauksessa.