### PR TITLE
Return precondition failed if errors exists on pistesyotto put

### DIFF
--- a/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/resource/PistesyottoResource.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/pistesyotto/resource/PistesyottoResource.java
@@ -208,7 +208,12 @@ public class PistesyottoResource {
                             pistetiedot, ifUnmodifiedSince, auditSession)
                         .toFuture()
                         .get();
-                result.setResult(ResponseEntity.status(HttpStatus.NO_CONTENT).body(errors));
+                result.setResult(
+                    ResponseEntity.status(
+                            errors.isEmpty()
+                                ? HttpStatus.NO_CONTENT
+                                : HttpStatus.PRECONDITION_FAILED)
+                        .body(errors));
               } else {
                 String msg =
                     String.format(
@@ -386,11 +391,10 @@ public class PistesyottoResource {
                         hakuOid, hakukohdeOid, ifUnmodifiedSince, pistetiedot, auditSession)))
         .subscribe(
             errors -> {
-              if (errors.isEmpty()) {
-                result.setResult(ResponseEntity.status(HttpStatus.NO_CONTENT).build());
-              } else {
-                result.setResult(ResponseEntity.status(HttpStatus.NO_CONTENT).body(errors));
-              }
+              result.setResult(
+                  ResponseEntity.status(
+                          errors.isEmpty() ? HttpStatus.NO_CONTENT : HttpStatus.PRECONDITION_FAILED)
+                      .body(errors));
             },
             error -> {
               if (error instanceof AccessDeniedException) {


### PR DESCRIPTION
Korjaa ongelman jossa konfliktaavia (ja täten ei tallennettuja) muutoksia ei palautettu jolloin käyttöliittymä antoi vaikutuksen siitä että tallennus onnistui.

Huomattu tiketin OK-1004 yhteydessä