### PR TITLE
OY-5537: Käytä jaettua gson-määritystä myös casClientissa

### DIFF
--- a/src/main/java/fi/vm/sade/valinta/kooste/external/resource/HttpClients.java
+++ b/src/main/java/fi/vm/sade/valinta/kooste/external/resource/HttpClients.java
@@ -155,7 +155,8 @@ public class HttpClients {
         new CasConfig.CasConfigBuilder(
                 username, password, ticketsUrl, service, CSRF_VALUE, CALLER_ID, "")
             .setJsessionName("session")
-            .build());
+            .build(),
+        ValintaTulosServiceAsyncResourceImpl.getGson());
   }
 
   @Bean(name = "OhjausparametritHttpClient")


### PR DESCRIPTION
Liittyy muutokseen https://github.com/Opetushallitus/valintalaskentakoostepalvelu/commit/2906e178d3816f2957af6a2d307f6fd5ecd08d6f
jonka yhteydessä vaihdettiin client casClientiin